### PR TITLE
File length is one byte less.

### DIFF
--- a/lib/meatloaf/cbm_media.cpp
+++ b/lib/meatloaf/cbm_media.cpp
@@ -65,7 +65,7 @@ uint16_t CBMImageStream::seekFileSize( uint8_t start_track, uint8_t start_sector
             seekSector( start_track, start_sector );
     } while ( start_track > 0 );
     blocks--;
-    return (blocks * (block_size - 2)) + start_sector;
+    return (blocks * (block_size - 2)) + start_sector - 1;
 };
 
 


### PR DESCRIPTION
Tested against the ZetaWing II d64 image. After going through it with the logic analyzer I could see that when loading the M1 file the Commodore was aborting after byte 619 and causing the EOI ack failure at byte 620. The game seems to know how many bytes it wants for some files and just quits after getting them all instead of waiting for EOI to be signalled.

Checked image against ninepin and worked fine there. Looked at the actual file length of M1 on the d64 image and it really is only 619 bytes. Looked at how ninepin calculates file length and it was nearly identical except for the `- 1`. Added `- 1` and now zetawing plays fine with disk image on the SD card.