### PR TITLE
Fix IEC DATA line latching low on an idle bus after an aborted ATN request

### DIFF
--- a/lib/bus/iec/IECBusHandler.cpp
+++ b/lib/bus/iec/IECBusHandler.cpp
@@ -4080,6 +4080,22 @@ void IECBusHandler::task()
     {
       // host has released ATN
       m_flags &= ~P_ATN;
+
+      // ATN was released before handleATNSequence() ran, i.e. no address byte
+      // was received (e.g. ATN glitched low while the host powers up, or we
+      // missed the sequence entirely). atnRequest() pulled DATA low ("I am
+      // here") and disabled the hardware ATN->DATA path; if no transaction is
+      // in progress nothing else will release DATA, leaving it latched low on
+      // an idle bus and wedging hosts that poll for bus-free before starting
+      // a transfer => restore the idle bus state
+      if( !(m_flags & (P_LISTENING|P_TALKING)) || (m_flags & P_DONE)!=0 )
+        {
+          writePinCLK(HIGH);
+          writePinDATA(HIGH);
+        }
+
+      // allow ATN to pull DATA low in hardware
+      writePinCTRL(LOW);
     }
 
   // ------------------ fast-load protocol handling -------------------


### PR DESCRIPTION
Fixes #45

## Problem

`atnRequest()` responds to an ATN falling edge by pulling DATA low ("I am here") and disabling the hardware ATN→DATA path (`writePinCTRL(HIGH)`), leaving the rest of the sequence to `handleATNSequence()`. If the host releases ATN **before** any address byte is received — e.g. bus-line flapping while the C64 powers up, which a USB-powered Meatloaf survives — `task()` takes this branch:

```cpp
else if( (m_flags & P_ATN)!=0 && readPinATN() )
  {
    // host has released ATN
    m_flags &= ~P_ATN;
  }
```

Only the flag is cleared. With no LISTEN/TALK transaction in progress, no other code path ever touches DATA again, so it stays latched low on a completely idle bus, and the hardware ATN→DATA pull stays disabled as well. Nothing is logged because `atnRequest()` runs in the ISR and `handleATNSequence()` (where all listen/talk handling lives) never ran — matching all the evidence in #45, including the stuck state surviving C64 power cycles.

Most software never notices since the stock KERNAL drives ATN unconditionally and the next real ATN sequence re-syncs everything. But anything that polls for bus-free before transferring — like the Kung Fu Flash 1 loader — spins forever.

## Fix

When ATN is released without the sequence having run, restore the idle bus state: release CLK and DATA, and re-enable the hardware ATN→DATA pull, mirroring what every other exit path from an ATN sequence already does (`handleATNSequence()` lines ~3761–3781).

The release is skipped if a transaction started before the glitch is still genuinely mid-flight (`P_LISTENING`/`P_TALKING` set without `P_DONE`), so a brief ATN blip during an active transfer doesn't stomp on the handshake. If the prior transaction had already finished (`P_DONE`), DATA had been deliberately released before the glitch re-asserted it, so releasing it again is correct.

## Testing

- Built and flashed on a Freenove ESP32-S3-WROOM-1 (16MB/8MB).
- Reproduced the hang from #45 (C64 + Kung Fu Flash 1, multi-part game freezing at its next load with DATA held low on an idle bus); with this fix the games load normally and DATA reads HIGH whenever the bus is idle, including across repeated C64 power cycles.
- Normal `LOAD"...",8` and JiffyDOS transfers unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)