### PR TITLE
Fix WebDAV writes from macOS Finder (empty files), and a 5s stall on every .local lookup

### DIFF
--- a/components/esp_http_server/CMakeLists.txt
+++ b/components/esp_http_server/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(priv_req mbedtls lwip esp_timer)
+set(priv_inc_dir "src/util" "src/port/esp32")
+set(requires http_parser esp_event)
+
+idf_component_register(SRCS "src/httpd_main.c"
+                            "src/httpd_parse.c"
+                            "src/httpd_sess.c"
+                            "src/httpd_txrx.c"
+                            "src/httpd_uri.c"
+                            "src/httpd_ws.c"
+                            "src/util/ctrl_sock.c"
+                    INCLUDE_DIRS "include"
+                    PRIV_INCLUDE_DIRS ${priv_inc_dir}
+                    REQUIRES ${requires}
+                    PRIV_REQUIRES ${priv_req})

--- a/components/esp_http_server/Kconfig
+++ b/components/esp_http_server/Kconfig
@@ -1,0 +1,66 @@
+menu "HTTP Server"
+
+
+    config HTTPD_MAX_REQ_HDR_LEN
+        int "HTTP Request Header Length limit"
+        default 1024
+        range 128 65536
+        help
+            This sets the default limit for the HTTP request header length. The limit can be
+            configured at run time by setting max_req_hdr_len member of httpd_config_t structure.
+            The memory allocated will depend on the actual header length. Hence keeping a sufficiently
+            large max header length is recommended.
+
+
+    config HTTPD_MAX_URI_LEN
+        int "Max HTTP URI Length"
+        default 512
+        help
+            This sets the maximum supported size of HTTP request URI to be processed by the server
+
+    config HTTPD_ERR_RESP_NO_DELAY
+        bool "Use TCP_NODELAY socket option when sending HTTP error responses"
+        default y
+        help
+            Using TCP_NODEALY socket option ensures that HTTP error response reaches the client before the
+            underlying socket is closed. Please note that turning this off may cause multiple test failures
+
+    config HTTPD_PURGE_BUF_LEN
+        int "Length of temporary buffer for purging data"
+        default 32
+        help
+            This sets the size of the temporary buffer used to receive and discard any remaining data that is
+            received from the HTTP client in the request, but not processed as part of the server HTTP request
+            handler.
+
+            If the remaining data is larger than the available buffer size, the buffer will be filled in multiple
+            iterations. The buffer should be small enough to fit on the stack, but large enough to avoid excessive
+            iterations.
+
+    config HTTPD_LOG_PURGE_DATA
+        bool "Log purged content data at Debug level"
+        default n
+        help
+            Enabling this will log discarded binary HTTP request data at Debug level.
+            For large content data this may not be desirable as it will clutter the log.
+
+    config HTTPD_WS_SUPPORT
+        bool "WebSocket server support"
+        default n
+        help
+            This sets the WebSocket server support.
+
+    config HTTPD_QUEUE_WORK_BLOCKING
+        bool "httpd_queue_work as blocking API"
+        help
+            This makes httpd_queue_work() API to wait until a message space is available on UDP control socket.
+            It internally uses a counting semaphore with count set to `LWIP_UDP_RECVMBOX_SIZE` to achieve this.
+            This config will slightly change API behavior to block until message gets delivered on control socket.
+
+    config HTTPD_SERVER_EVENT_POST_TIMEOUT
+        int "Time in millisecond to wait for posting event"
+        default 2000
+        help
+            This config option helps in setting the time in millisecond to wait for event to be posted to the
+            system default event loop. Set it to -1 if you need to set timeout to portMAX_DELAY.
+endmenu

--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -1,0 +1,1820 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _ESP_HTTP_SERVER_H_
+#define _ESP_HTTP_SERVER_H_
+
+#include <stdio.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <http_parser.h>
+#include <sdkconfig.h>
+#include <esp_err.h>
+#include <esp_event.h>
+#include <esp_event_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_HTTPD_DEF_CTRL_PORT         (32768)    /*!< HTTP Server control socket port*/
+
+ESP_EVENT_DECLARE_BASE(ESP_HTTP_SERVER_EVENT);
+
+/**
+ * @brief   HTTP Server events id
+ */
+typedef enum {
+    HTTP_SERVER_EVENT_ERROR = 0,       /*!< This event occurs when there are any errors during execution */
+    HTTP_SERVER_EVENT_START,           /*!< This event occurs when HTTP Server is started */
+    HTTP_SERVER_EVENT_ON_CONNECTED,    /*!< Once the HTTP Server has been connected to the client, no data exchange has been performed */
+    HTTP_SERVER_EVENT_ON_HEADER,       /*!< Occurs when receiving each header sent from the client */
+    HTTP_SERVER_EVENT_HEADERS_SENT,     /*!< After sending all the headers to the client */
+    HTTP_SERVER_EVENT_ON_DATA,         /*!< Occurs when receiving data from the client */
+    HTTP_SERVER_EVENT_SENT_DATA,       /*!< Occurs when an ESP HTTP server session is finished */
+    HTTP_SERVER_EVENT_DISCONNECTED,    /*!< The connection has been disconnected */
+    HTTP_SERVER_EVENT_STOP,            /*!< This event occurs when HTTP Server is stopped */
+} esp_http_server_event_id_t;
+
+/** Argument structure for HTTP_SERVER_EVENT_ON_DATA and HTTP_SERVER_EVENT_SENT_DATA event */
+typedef struct {
+    int fd;         /*!< Session socket file descriptor */
+    int data_len;   /*!< Data length */
+} esp_http_server_event_data;
+
+/*
+note: esp_https_server.h includes a customized copy of this
+initializer that should be kept in sync
+*/
+#define HTTPD_DEFAULT_CONFIG() {                        \
+        .task_priority      = tskIDLE_PRIORITY+5,       \
+        .stack_size         = 4096,                     \
+        .core_id            = tskNO_AFFINITY,           \
+        .task_caps          = (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),       \
+        .max_req_hdr_len    = CONFIG_HTTPD_MAX_REQ_HDR_LEN,    \
+        .max_uri_len        = CONFIG_HTTPD_MAX_URI_LEN,        \
+        .server_port        = 80,                       \
+        .ctrl_port          = ESP_HTTPD_DEF_CTRL_PORT,  \
+        .max_open_sockets   = 7,                        \
+        .max_uri_handlers   = 8,                        \
+        .max_resp_headers   = 8,                        \
+        .backlog_conn       = 5,                        \
+        .lru_purge_enable   = false,                    \
+        .recv_wait_timeout  = 5,                        \
+        .send_wait_timeout  = 5,                        \
+        .global_user_ctx = NULL,                        \
+        .global_user_ctx_free_fn = NULL,                \
+        .global_transport_ctx = NULL,                   \
+        .global_transport_ctx_free_fn = NULL,           \
+        .enable_so_linger = false,                      \
+        .linger_timeout = 0,                            \
+        .keep_alive_enable = false,                     \
+        .keep_alive_idle = 0,                           \
+        .keep_alive_interval = 0,                       \
+        .keep_alive_count = 0,                          \
+        .open_fn = NULL,                                \
+        .close_fn = NULL,                               \
+        .uri_match_fn = NULL                            \
+}
+
+#define ESP_ERR_HTTPD_BASE              (0xb000)                    /*!< Starting number of HTTPD error codes */
+#define ESP_ERR_HTTPD_HANDLERS_FULL     (ESP_ERR_HTTPD_BASE +  1)   /*!< All slots for registering URI handlers have been consumed */
+#define ESP_ERR_HTTPD_HANDLER_EXISTS    (ESP_ERR_HTTPD_BASE +  2)   /*!< URI handler with same method and target URI already registered */
+#define ESP_ERR_HTTPD_INVALID_REQ       (ESP_ERR_HTTPD_BASE +  3)   /*!< Invalid request pointer */
+#define ESP_ERR_HTTPD_RESULT_TRUNC      (ESP_ERR_HTTPD_BASE +  4)   /*!< Result string truncated */
+#define ESP_ERR_HTTPD_RESP_HDR          (ESP_ERR_HTTPD_BASE +  5)   /*!< Response header field larger than supported */
+#define ESP_ERR_HTTPD_RESP_SEND         (ESP_ERR_HTTPD_BASE +  6)   /*!< Error occurred while sending response packet */
+#define ESP_ERR_HTTPD_ALLOC_MEM         (ESP_ERR_HTTPD_BASE +  7)   /*!< Failed to dynamically allocate memory for resource */
+#define ESP_ERR_HTTPD_TASK              (ESP_ERR_HTTPD_BASE +  8)   /*!< Failed to launch server task/thread */
+
+/* Symbol to be used as length parameter in httpd_resp_send APIs
+ * for setting buffer length to string length */
+#define HTTPD_RESP_USE_STRLEN -1
+
+/* ************** Group: Initialization ************** */
+/** @name Initialization
+ * APIs related to the Initialization of the web server
+ * @{
+ */
+
+/**
+ * @brief   HTTP Server Instance Handle
+ *
+ * Every instance of the server will have a unique handle.
+ */
+typedef void* httpd_handle_t;
+
+/**
+ * @brief   HTTP Method Type wrapper over "enum http_method"
+ *          available in "http_parser" library
+ */
+typedef enum http_method httpd_method_t;
+
+#define HTTP_ANY INT_MAX
+
+/**
+ * @brief  Prototype for freeing context data (if any)
+ * @param[in] ctx   object to free
+ */
+typedef void (*httpd_free_ctx_fn_t)(void *ctx);
+
+/**
+ * @brief  Function prototype for opening a session.
+ *
+ * Called immediately after the socket was opened to set up the send/recv functions and
+ * other parameters of the socket.
+ *
+ * @param[in] hd       server instance
+ * @param[in] sockfd   session socket file descriptor
+ * @return
+ *  - ESP_OK   : On success
+ *  - Any value other than ESP_OK will signal the server to close the socket immediately
+ */
+typedef esp_err_t (*httpd_open_func_t)(httpd_handle_t hd, int sockfd);
+
+/**
+ * @brief  Function prototype for closing a session.
+ *
+ * @note   It's possible that the socket descriptor is invalid at this point, the function
+ *         is called for all terminated sessions. Ensure proper handling of return codes.
+ *
+ * @param[in] hd   server instance
+ * @param[in] sockfd   session socket file descriptor
+ */
+typedef void (*httpd_close_func_t)(httpd_handle_t hd, int sockfd);
+
+/**
+ * @brief  Function prototype for URI matching.
+ *
+ * @param[in] reference_uri   URI/template with respect to which the other URI is matched
+ * @param[in] uri_to_match    URI/template being matched to the reference URI/template
+ * @param[in] match_upto      For specifying the actual length of `uri_to_match` up to
+ *                            which the matching algorithm is to be applied (The maximum
+ *                            value is `strlen(uri_to_match)`, independent of the length
+ *                            of `reference_uri`)
+ * @return true on match
+ */
+typedef bool (*httpd_uri_match_func_t)(const char *reference_uri,
+                                       const char *uri_to_match,
+                                       size_t match_upto);
+
+/**
+ * @brief   HTTP Server Configuration Structure
+ *
+ * @note    Use HTTPD_DEFAULT_CONFIG() to initialize the configuration
+ *          to a default value and then modify only those fields that are
+ *          specifically determined by the use case.
+ */
+typedef struct httpd_config {
+    unsigned    task_priority;      /*!< Priority of FreeRTOS task which runs the server */
+    size_t      stack_size;         /*!< The maximum stack size allowed for the server task */
+    BaseType_t  core_id;            /*!< The core the HTTP server task will run on */
+    uint32_t    task_caps;          /*!< The memory capabilities to use when allocating the HTTP server task's stack */
+
+    /**
+     * Size limits for the header and URI buffers respectively.
+     * These are just limits, allocation would depend upon actual size of URI/header.
+     */
+    size_t max_req_hdr_len;    /*!< Size limit for the header buffer (By default this value is set to CONFIG_HTTPD_MAX_REQ_HDR_LEN, overwrite is possible) */
+    size_t max_uri_len;    /*!< Size limit for the URI buffer By default this value is set to CONFIG_HTTPD_MAX_URI_LEN, overwrite is possible) */
+
+    /**
+     * TCP Port number for receiving and transmitting HTTP traffic
+     */
+    uint16_t    server_port;
+
+    /**
+     * UDP Port number for asynchronously exchanging control signals
+     * between various components of the server
+     */
+    uint16_t    ctrl_port;
+
+    uint16_t    max_open_sockets;   /*!< Max number of sockets/clients connected at any time (3 sockets are reserved for internal working of the HTTP server) */
+    uint16_t    max_uri_handlers;   /*!< Maximum allowed uri handlers */
+    uint16_t    max_resp_headers;   /*!< Maximum allowed additional headers in HTTP response */
+    uint16_t    backlog_conn;       /*!< Number of backlog connections */
+    bool        lru_purge_enable;   /*!< Purge "Least Recently Used" connection */
+    uint16_t    recv_wait_timeout;  /*!< Timeout for recv function (in seconds)*/
+    uint16_t    send_wait_timeout;  /*!< Timeout for send function (in seconds)*/
+
+    /**
+     * Global user context.
+     *
+     * This field can be used to store arbitrary user data within the server context.
+     * The value can be retrieved using the server handle, available e.g. in the httpd_req_t struct.
+     *
+     * When shutting down, the server frees up the user context by
+     * calling free() on the global_user_ctx field. If you wish to use a custom
+     * function for freeing the global user context, please specify that here.
+     */
+    void * global_user_ctx;
+
+    /**
+     * Free function for global user context
+     */
+    httpd_free_ctx_fn_t global_user_ctx_free_fn;
+
+    /**
+     * Global transport context.
+     *
+     * Similar to global_user_ctx, but used for session encoding or encryption (e.g. to hold the SSL context).
+     * It will be freed using free(), unless global_transport_ctx_free_fn is specified.
+     */
+    void * global_transport_ctx;
+
+    /**
+     * Free function for global transport context
+     */
+    httpd_free_ctx_fn_t global_transport_ctx_free_fn;
+
+    bool enable_so_linger;  /*!< bool to enable/disable linger */
+    int linger_timeout;     /*!< linger timeout (in seconds) */
+    bool keep_alive_enable; /*!< Enable keep-alive timeout */
+    int keep_alive_idle;    /*!< Keep-alive idle time. Default is 5 (second) */
+    int keep_alive_interval;/*!< Keep-alive interval time. Default is 5 (second) */
+    int keep_alive_count;   /*!< Keep-alive packet retry send count. Default is 3 counts */
+    /**
+     * Custom session opening callback.
+     *
+     * Called on a new session socket just after accept(), but before reading any data.
+     *
+     * This is an opportunity to set up e.g. SSL encryption using global_transport_ctx
+     * and the send/recv/pending session overrides.
+     *
+     * If a context needs to be maintained between these functions, store it in the session using
+     * httpd_sess_set_transport_ctx() and retrieve it later with httpd_sess_get_transport_ctx()
+     *
+     * Returning a value other than ESP_OK will immediately close the new socket.
+     */
+    httpd_open_func_t open_fn;
+
+    /**
+     * Custom session closing callback.
+     *
+     * Called when a session is deleted, before freeing user and transport contexts and before
+     * closing the socket. This is a place for custom de-init code common to all sockets.
+     *
+     * The server will only close the socket if no custom session closing callback is set.
+     * If a custom callback is used, `close(sockfd)` should be called in here for most cases.
+     *
+     * Set the user or transport context to NULL if it was freed here, so the server does not
+     * try to free it again.
+     *
+     * This function is run for all terminated sessions, including sessions where the socket
+     * was closed by the network stack - that is, the file descriptor may not be valid anymore.
+     */
+    httpd_close_func_t close_fn;
+
+    /**
+     * URI matcher function.
+     *
+     * Called when searching for a matching URI:
+     *     1) whose request handler is to be executed right
+     *        after an HTTP request is successfully parsed
+     *     2) in order to prevent duplication while registering
+     *        a new URI handler using `httpd_register_uri_handler()`
+     *
+     * Available options are:
+     *     1) NULL : Internally do basic matching using `strncmp()`
+     *     2) `httpd_uri_match_wildcard()` : URI wildcard matcher
+     *
+     * Users can implement their own matching functions (See description
+     * of the `httpd_uri_match_func_t` function prototype)
+     */
+    httpd_uri_match_func_t uri_match_fn;
+} httpd_config_t;
+
+/**
+ * @brief Starts the web server
+ *
+ * Create an instance of HTTP server and allocate memory/resources for it
+ * depending upon the specified configuration.
+ *
+ * Example usage:
+ * @code{c}
+ *
+ * //Function for starting the webserver
+ * httpd_handle_t start_webserver(void)
+ * {
+ *      // Generate default configuration
+ *      httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+ *
+ *      // Empty handle to http_server
+ *      httpd_handle_t server = NULL;
+ *
+ *      // Start the httpd server
+ *      if (httpd_start(&server, &config) == ESP_OK) {
+ *          // Register URI handlers
+ *          httpd_register_uri_handler(server, &uri_get);
+ *          httpd_register_uri_handler(server, &uri_post);
+ *      }
+ *      // If server failed to start, handle will be NULL
+ *      return server;
+ * }
+ *
+ * @endcode
+ *
+ * @param[in]  config   Configuration for new instance of the server
+ * @param[out] handle   Handle to newly created instance of the server. NULL on error
+ * @return
+ *  - ESP_OK    : Instance created successfully
+ *  - ESP_ERR_INVALID_ARG      : Null argument(s)
+ *  - ESP_ERR_HTTPD_ALLOC_MEM  : Failed to allocate memory for instance
+ *  - ESP_ERR_HTTPD_TASK       : Failed to launch server task
+ */
+esp_err_t httpd_start(httpd_handle_t *handle, const httpd_config_t *config);
+
+/**
+ * @brief Stops the web server
+ *
+ * Deallocates memory/resources used by an HTTP server instance and
+ * deletes it. Once deleted the handle can no longer be used for accessing
+ * the instance.
+ *
+ * Example usage:
+ * @code{c}
+ *
+ * // Function for stopping the webserver
+ * void stop_webserver(httpd_handle_t server)
+ * {
+ *      // Ensure handle is non NULL
+ *      if (server != NULL) {
+ *          // Stop the httpd server
+ *          httpd_stop(server);
+ *      }
+ * }
+ *
+ * @endcode
+ *
+ * @param[in] handle Handle to server returned by httpd_start
+ * @return
+ *  - ESP_OK : Server stopped successfully
+ *  - ESP_ERR_INVALID_ARG : Handle argument is Null
+ */
+esp_err_t httpd_stop(httpd_handle_t handle);
+
+/** End of Group Initialization
+ * @}
+ */
+
+/* ************** Group: URI Handlers ************** */
+/** @name URI Handlers
+ * APIs related to the URI handlers
+ * @{
+ */
+
+/**
+ * @brief HTTP Request Data Structure
+ */
+typedef struct httpd_req {
+    httpd_handle_t  handle;                     /*!< Handle to server instance */
+    int             method;                     /*!< The type of HTTP request, -1 if unsupported method, HTTP_ANY for wildcard method to support every method */
+    const char      uri[CONFIG_HTTPD_MAX_URI_LEN + 1]; /*!< The URI of this request (1 byte extra for null termination) */
+    size_t          content_len;                /*!< Length of the request body */
+    void           *aux;                        /*!< Internally used members */
+
+    /**
+     * User context pointer passed during URI registration.
+     */
+    void *user_ctx;
+
+    /**
+     * Session Context Pointer
+     *
+     * A session context. Contexts are maintained across 'sessions' for a
+     * given open TCP connection. One session could have multiple request
+     * responses. The web server will ensure that the context persists
+     * across all these request and responses.
+     *
+     * By default, this is NULL. URI Handlers can set this to any meaningful
+     * value.
+     *
+     * If the underlying socket gets closed, and this pointer is non-NULL,
+     * the web server will free up the context by calling free(), unless
+     * free_ctx function is set.
+     */
+    void *sess_ctx;
+
+    /**
+     * Pointer to free context hook
+     *
+     * Function to free session context
+     *
+     * If the web server's socket closes, it frees up the session context by
+     * calling free() on the sess_ctx member. If you wish to use a custom
+     * function for freeing the session context, please specify that here.
+     */
+    httpd_free_ctx_fn_t free_ctx;
+
+    /**
+     * Flag indicating if Session Context changes should be ignored
+     *
+     * By default, if you change the sess_ctx in some URI handler, the http server
+     * will internally free the earlier context (if non NULL), after the URI handler
+     * returns. If you want to manage the allocation/reallocation/freeing of
+     * sess_ctx yourself, set this flag to true, so that the server will not
+     * perform any checks on it. The context will be cleared by the server
+     * (by calling free_ctx or free()) only if the socket gets closed.
+     */
+    bool ignore_sess_ctx_changes;
+} httpd_req_t;
+
+/**
+ * @brief Structure for URI handler
+ */
+typedef struct httpd_uri {
+    const char       *uri;    /*!< The URI to handle */
+    httpd_method_t    method; /*!< Method supported by the URI, HTTP_ANY for wildcard method to support all methods*/
+
+    /**
+     * Handler to call for supported request method. This must
+     * return ESP_OK, or else the underlying socket will be closed.
+     */
+    esp_err_t (*handler)(httpd_req_t *r);
+
+    /**
+     * Pointer to user context data which will be available to handler
+     */
+    void *user_ctx;
+
+#if CONFIG_HTTPD_WS_SUPPORT || __DOXYGEN__
+    /**
+     * Flag for indicating a WebSocket endpoint.
+     * If this flag is true, then method must be HTTP_GET. Otherwise the handshake will not be handled.
+     */
+    bool is_websocket;
+
+    /**
+     * Flag indicating that control frames (PING, PONG, CLOSE) are also passed to the handler
+     * This is used if a custom processing of the control frames is needed
+     */
+    bool handle_ws_control_frames;
+
+    /**
+     * Pointer to subprotocol supported by URI
+     */
+    const char *supported_subprotocol;
+#endif
+} httpd_uri_t;
+
+/**
+ * @brief   Registers a URI handler
+ *
+ * @note    URI handlers can be registered in real time as long as the
+ *          server handle is valid.
+ *
+ * Example usage:
+ * @code{c}
+ *
+ * esp_err_t my_uri_handler(httpd_req_t* req)
+ * {
+ *     // Recv , Process and Send
+ *     ....
+ *     ....
+ *     ....
+ *
+ *     // Fail condition
+ *     if (....) {
+ *         // Return fail to close session //
+ *         return ESP_FAIL;
+ *     }
+ *
+ *     // On success
+ *     return ESP_OK;
+ * }
+ *
+ * // URI handler structure
+ * httpd_uri_t my_uri {
+ *     .uri      = "/my_uri/path/xyz",
+ *     .method   = HTTP_GET,
+ *     .handler  = my_uri_handler,
+ *     .user_ctx = NULL
+ * };
+ *
+ * // Register handler
+ * if (httpd_register_uri_handler(server_handle, &my_uri) != ESP_OK) {
+ *    // If failed to register handler
+ *    ....
+ * }
+ *
+ * @endcode
+ *
+ * @param[in] handle      handle to HTTPD server instance
+ * @param[in] uri_handler pointer to handler that needs to be registered
+ *
+ * @return
+ *  - ESP_OK : On successfully registering the handler
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_HANDLERS_FULL  : If no slots left for new handler
+ *  - ESP_ERR_HTTPD_HANDLER_EXISTS : If handler with same URI and
+ *                                   method is already registered
+ */
+esp_err_t httpd_register_uri_handler(httpd_handle_t handle,
+                                     const httpd_uri_t *uri_handler);
+
+/**
+ * @brief   Unregister a URI handler
+ *
+ * @param[in] handle    handle to HTTPD server instance
+ * @param[in] uri       URI string
+ * @param[in] method    HTTP method
+ *
+ * @return
+ *  - ESP_OK : On successfully deregistering the handler
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_NOT_FOUND   : Handler with specified URI and method not found
+ */
+esp_err_t httpd_unregister_uri_handler(httpd_handle_t handle,
+                                       const char *uri, httpd_method_t method);
+
+/**
+ * @brief   Unregister all URI handlers with the specified uri string
+ *
+ * @param[in] handle   handle to HTTPD server instance
+ * @param[in] uri      uri string specifying all handlers that need
+ *                     to be deregisterd
+ *
+ * @return
+ *  - ESP_OK : On successfully deregistering all such handlers
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_NOT_FOUND   : No handler registered with specified uri string
+ */
+esp_err_t httpd_unregister_uri(httpd_handle_t handle, const char* uri);
+
+/** End of URI Handlers
+ * @}
+ */
+
+/* ************** Group: HTTP Error ************** */
+/** @name HTTP Error
+ * Prototype for HTTP errors and error handling functions
+ * @{
+ */
+
+/**
+ * @brief Error codes sent as HTTP response in case of errors
+ *        encountered during processing of an HTTP request
+ */
+typedef enum {
+    /* For any unexpected errors during parsing, like unexpected
+     * state transitions, or unhandled errors.
+     */
+    HTTPD_500_INTERNAL_SERVER_ERROR = 0,
+
+    /* For methods not supported by http_parser. Presently
+     * http_parser halts parsing when such methods are
+     * encountered and so the server responds with 400 Bad
+     * Request error instead.
+     */
+    HTTPD_501_METHOD_NOT_IMPLEMENTED,
+
+    /* When HTTP version is not 1.1 or 1.0*/
+    HTTPD_505_VERSION_NOT_SUPPORTED,
+
+    /* Returned when http_parser halts parsing due to incorrect
+     * syntax of request, unsupported method in request URI or
+     * due to chunked encoding / upgrade field present in headers
+     */
+    HTTPD_400_BAD_REQUEST,
+
+    /* This response means the client must authenticate itself
+     * to get the requested response.
+     */
+    HTTPD_401_UNAUTHORIZED,
+
+    /* The client does not have access rights to the content,
+     * so the server is refusing to give the requested resource.
+     * Unlike 401, the client's identity is known to the server.
+     */
+    HTTPD_403_FORBIDDEN,
+
+    /* When requested URI is not found */
+    HTTPD_404_NOT_FOUND,
+
+    /* When URI found, but method has no handler registered */
+    HTTPD_405_METHOD_NOT_ALLOWED,
+
+    /* Intended for recv timeout. Presently it's being sent
+     * for other recv errors as well. Client should expect the
+     * server to immediately close the connection after
+     * responding with this.
+     */
+    HTTPD_408_REQ_TIMEOUT,
+
+    /* Intended for responding to chunked encoding, which is
+     * not supported currently. Though unhandled http_parser
+     * callback for chunked request returns "400 Bad Request"
+     */
+    HTTPD_411_LENGTH_REQUIRED,
+
+    /* Incoming payload is too large */
+    HTTPD_413_CONTENT_TOO_LARGE,
+
+    /* URI length greater than CONFIG_CONFIG_HTTPD_MAX_URI_LEN */
+    HTTPD_414_URI_TOO_LONG,
+
+    /* Headers section larger than CONFIG_CONFIG_HTTPD_MAX_REQ_HDR_LEN */
+    HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE,
+
+    /* Used internally for retrieving the total count of errors */
+    HTTPD_ERR_CODE_MAX
+} httpd_err_code_t;
+
+/**
+ * @brief  Function prototype for HTTP error handling.
+ *
+ * This function is executed upon HTTP errors generated during
+ * internal processing of an HTTP request. This is used to override
+ * the default behavior on error, which is to send HTTP error response
+ * and close the underlying socket.
+ *
+ * @note
+ *  - If implemented, the server will not automatically send out HTTP
+ *    error response codes, therefore, httpd_resp_send_err() must be
+ *    invoked inside this function if user wishes to generate HTTP
+ *    error responses.
+ *  - When invoked, the validity of `uri`, `method`, `content_len`
+ *    and `user_ctx` fields of the httpd_req_t parameter is not
+ *    guaranteed as the HTTP request may be partially received/parsed.
+ *  - The function must return ESP_OK if underlying socket needs to
+ *    be kept open. Any other value will ensure that the socket is
+ *    closed. The return value is ignored when error is of type
+ *    `HTTPD_500_INTERNAL_SERVER_ERROR` and the socket closed anyway.
+ *
+ * @param[in] req    HTTP request for which the error needs to be handled
+ * @param[in] error  Error type
+ *
+ * @return
+ *  - ESP_OK   : error handled successful
+ *  - ESP_FAIL : failure indicates that the underlying socket needs to be closed
+ */
+typedef esp_err_t (*httpd_err_handler_func_t)(httpd_req_t *req,
+                                              httpd_err_code_t error);
+
+/**
+ * @brief  Function for registering HTTP error handlers
+ *
+ * This function maps a handler function to any supported error code
+ * given by `httpd_err_code_t`. See prototype `httpd_err_handler_func_t`
+ * above for details.
+ *
+ * @param[in] handle     HTTP server handle
+ * @param[in] error      Error type
+ * @param[in] handler_fn User implemented handler function
+ *                       (Pass NULL to unset any previously set handler)
+ *
+ * @return
+ *  - ESP_OK : handler registered successfully
+ *  - ESP_ERR_INVALID_ARG : invalid error code or server handle
+ */
+esp_err_t httpd_register_err_handler(httpd_handle_t handle,
+                                     httpd_err_code_t error,
+                                     httpd_err_handler_func_t handler_fn);
+
+/** End of HTTP Error
+ * @}
+ */
+
+/* ************** Group: TX/RX ************** */
+/** @name TX / RX
+ * Prototype for HTTPDs low-level send/recv functions
+ * @{
+ */
+
+#define HTTPD_SOCK_ERR_FAIL      -1
+#define HTTPD_SOCK_ERR_INVALID   -2
+#define HTTPD_SOCK_ERR_TIMEOUT   -3
+
+/**
+ * @brief  Prototype for HTTPDs low-level send function
+ *
+ * @note   User specified send function must handle errors internally,
+ *         depending upon the set value of errno, and return specific
+ *         HTTPD_SOCK_ERR_ codes, which will eventually be conveyed as
+ *         return value of httpd_send() function
+ *
+ * @param[in] hd        server instance
+ * @param[in] sockfd    session socket file descriptor
+ * @param[in] buf       buffer with bytes to send
+ * @param[in] buf_len   data size
+ * @param[in] flags     flags for the send() function
+ * @return
+ *  - Bytes : The number of bytes sent successfully
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket send()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket send()
+ */
+typedef int (*httpd_send_func_t)(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags);
+
+/**
+ * @brief  Prototype for HTTPDs low-level recv function
+ *
+ * @note   User specified recv function must handle errors internally,
+ *         depending upon the set value of errno, and return specific
+ *         HTTPD_SOCK_ERR_ codes, which will eventually be conveyed as
+ *         return value of httpd_req_recv() function
+ *
+ * @param[in] hd        server instance
+ * @param[in] sockfd    session socket file descriptor
+ * @param[in] buf       buffer with bytes to send
+ * @param[in] buf_len   data size
+ * @param[in] flags     flags for the send() function
+ * @return
+ *  - Bytes : The number of bytes received successfully
+ *  - 0     : Buffer length parameter is zero / connection closed by peer
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket recv()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket recv()
+ */
+typedef int (*httpd_recv_func_t)(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
+
+/**
+ * @brief  Prototype for HTTPDs low-level "get pending bytes" function
+ *
+ * @note   User specified pending function must handle errors internally,
+ *         depending upon the set value of errno, and return specific
+ *         HTTPD_SOCK_ERR_ codes, which will be handled accordingly in
+ *         the server task.
+ *
+ * @param[in] hd       server instance
+ * @param[in] sockfd   session socket file descriptor
+ * @return
+ *  - Bytes : The number of bytes waiting to be received
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket pending()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket pending()
+ */
+typedef int (*httpd_pending_func_t)(httpd_handle_t hd, int sockfd);
+
+/** End of TX / RX
+ * @}
+ */
+
+/* ************** Group: Request/Response ************** */
+/** @name Request / Response
+ * APIs related to the data send/receive by URI handlers.
+ * These APIs are supposed to be called only from the context of
+ * a URI handler where httpd_req_t* request pointer is valid.
+ * @{
+ */
+
+/**
+ * @brief   Override web server's receive function (by session FD)
+ *
+ * This function overrides the web server's receive function. This same function is
+ * used to read HTTP request packets.
+ *
+ * @note    This API is supposed to be called either from the context of
+ *          - an http session APIs where sockfd is a valid parameter
+ *          - a URI handler where sockfd is obtained using httpd_req_to_sockfd()
+ *
+ * @param[in] hd        HTTPD instance handle
+ * @param[in] sockfd    Session socket FD
+ * @param[in] recv_func The receive function to be set for this session
+ *
+ * @return
+ *  - ESP_OK : On successfully registering override
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_set_recv_override(httpd_handle_t hd, int sockfd, httpd_recv_func_t recv_func);
+
+/**
+ * @brief   Override web server's send function (by session FD)
+ *
+ * This function overrides the web server's send function. This same function is
+ * used to send out any response to any HTTP request.
+ *
+ * @note    This API is supposed to be called either from the context of
+ *          - an http session APIs where sockfd is a valid parameter
+ *          - a URI handler where sockfd is obtained using httpd_req_to_sockfd()
+ *
+ * @param[in] hd        HTTPD instance handle
+ * @param[in] sockfd    Session socket FD
+ * @param[in] send_func The send function to be set for this session
+ *
+ * @return
+ *  - ESP_OK : On successfully registering override
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_set_send_override(httpd_handle_t hd, int sockfd, httpd_send_func_t send_func);
+
+/**
+ * @brief   Override web server's pending function (by session FD)
+ *
+ * This function overrides the web server's pending function. This function is
+ * used to test for pending bytes in a socket.
+ *
+ * @note    This API is supposed to be called either from the context of
+ *          - an http session APIs where sockfd is a valid parameter
+ *          - a URI handler where sockfd is obtained using httpd_req_to_sockfd()
+ *
+ * @param[in] hd           HTTPD instance handle
+ * @param[in] sockfd       Session socket FD
+ * @param[in] pending_func The receive function to be set for this session
+ *
+ * @return
+ *  - ESP_OK : On successfully registering override
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_set_pending_override(httpd_handle_t hd, int sockfd, httpd_pending_func_t pending_func);
+
+/**
+ * @brief   Start an asynchronous request. This function can be called
+ *          in a request handler to get a request copy that can be used on a async thread.
+ *
+ * @note
+ * - This function is necessary in order to handle multiple requests simultaneously.
+ * See examples/async_requests for example usage.
+ * - You must call httpd_req_async_handler_complete() when you are done with the request.
+ *
+ * @param[in]   r       The request to create an async copy of
+ * @param[out]  out     A newly allocated request which can be used on an async thread
+ *
+ * @return
+ *  - ESP_OK : async request object created
+ */
+esp_err_t httpd_req_async_handler_begin(httpd_req_t *r, httpd_req_t **out);
+
+/**
+ * @brief   Mark an asynchronous request as completed. This will
+ *  - free the request memory
+ *  - relinquish ownership of the underlying socket, so it can be reused.
+ *  - allow the http server to close our socket if needed (lru_purge_enable)
+ *
+ * @note If async requests are not marked completed, eventually the server
+ * will no longer accept incoming connections. The server will log a
+ * "httpd_accept_conn: error in accept (23)" message if this happens.
+ *
+ * @param[in]   r   The request to mark async work as completed
+ *
+ * @return
+ *  - ESP_OK : async request was marked completed
+ */
+esp_err_t httpd_req_async_handler_complete(httpd_req_t *r);
+
+/**
+ * @brief   Get the Socket Descriptor from the HTTP request
+ *
+ * This API will return the socket descriptor of the session for
+ * which URI handler was executed on reception of HTTP request.
+ * This is useful when user wants to call functions that require
+ * session socket fd, from within a URI handler, ie. :
+ *      httpd_sess_get_ctx(),
+ *      httpd_sess_trigger_close(),
+ *      httpd_sess_update_lru_counter().
+ *
+ * @note    This API is supposed to be called only from the context of
+ *          a URI handler where httpd_req_t* request pointer is valid.
+ *
+ * @param[in] r The request whose socket descriptor should be found
+ *
+ * @return
+ *  - Socket descriptor : The socket descriptor for this request
+ *  - -1 : Invalid/NULL request pointer
+ */
+int httpd_req_to_sockfd(httpd_req_t *r);
+
+/**
+ * @brief   API to read content data from the HTTP request
+ *
+ * This API will read HTTP content data from the HTTP request into
+ * provided buffer. Use content_len provided in httpd_req_t structure
+ * to know the length of data to be fetched. If content_len is too
+ * large for the buffer then user may have to make multiple calls to
+ * this function, each time fetching 'buf_len' number of bytes,
+ * while the pointer to content data is incremented internally by
+ * the same number.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - If an error is returned, the URI handler must further return an error.
+ *    This will ensure that the erroneous socket is closed and cleaned up by
+ *    the web server.
+ *  - Presently Chunked Encoding is not supported
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Pointer to a buffer that the data will be read into
+ * @param[in] buf_len   Length of the buffer
+ *
+ * @return
+ *  - Bytes : Number of bytes read into the buffer successfully
+ *  - 0     : Buffer length parameter is zero / connection closed by peer
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket recv()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket recv()
+ */
+int httpd_req_recv(httpd_req_t *r, char *buf, size_t buf_len);
+
+/**
+ * @brief   Search for a field in request headers and
+ *          return the string length of it's value
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once httpd_resp_send() API is called all request headers
+ *    are purged, so request headers need be copied into separate
+ *    buffers if they are required later.
+ *
+ * @param[in]  r        The request being responded to
+ * @param[in]  field    The header field to be searched in the request
+ *
+ * @return
+ *  - Length    : If field is found in the request URL
+ *  - Zero      : Field not found / Invalid request / Null arguments
+ */
+size_t httpd_req_get_hdr_value_len(httpd_req_t *r, const char *field);
+
+/**
+ * @brief   Get the value string of a field from the request headers
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once httpd_resp_send() API is called all request headers
+ *    are purged, so request headers need be copied into separate
+ *    buffers if they are required later.
+ *  - If output size is greater than input, then the value is truncated,
+ *    accompanied by truncation error as return value.
+ *  - Use httpd_req_get_hdr_value_len() to know the right buffer length
+ *
+ * @param[in]  r        The request being responded to
+ * @param[in]  field    The field to be searched in the header
+ * @param[out] val      Pointer to the buffer into which the value will be copied if the field is found
+ * @param[in]  val_size Size of the user buffer "val"
+ *
+ * @return
+ *  - ESP_OK : Field found in the request header and value string copied
+ *  - ESP_ERR_NOT_FOUND          : Key not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ  : Invalid HTTP request pointer
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
+ */
+esp_err_t httpd_req_get_hdr_value_str(httpd_req_t *r, const char *field, char *val, size_t val_size);
+
+/**
+ * @brief   Get Query string length from the request URL
+ *
+ * @note    This API is supposed to be called only from the context of
+ *          a URI handler where httpd_req_t* request pointer is valid
+ *
+ * @param[in]  r    The request being responded to
+ *
+ * @return
+ *  - Length    : Query is found in the request URL
+ *  - Zero      : Query not found / Null arguments / Invalid request / uri is empty
+ */
+size_t httpd_req_get_url_query_len(httpd_req_t *r);
+
+/**
+ * @brief   Get Query string from the request URL
+ *
+ * @note
+ *  - Presently, the user can fetch the full URL query string, but decoding
+ *    will have to be performed by the user. Request headers can be read using
+ *    httpd_req_get_hdr_value_str() to know the 'Content-Type' (eg. Content-Type:
+ *    application/x-www-form-urlencoded) and then the appropriate decoding
+ *    algorithm needs to be applied.
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid
+ *  - If output size is greater than input, then the value is truncated,
+ *    accompanied by truncation error as return value
+ *  - Prior to calling this function, one can use httpd_req_get_url_query_len()
+ *    to know the query string length beforehand and hence allocate the buffer
+ *    of right size (usually query string length + 1 for null termination)
+ *    for storing the query string
+ *
+ * @param[in]  r         The request being responded to
+ * @param[out] buf       Pointer to the buffer into which the query string will be copied (if found)
+ * @param[in]  buf_len   Length of output buffer
+ *
+ * @return
+ *  - ESP_OK : Query is found in the request URL and copied to buffer
+ *  - ESP_FAIL                   : uri is empty
+ *  - ESP_ERR_NOT_FOUND          : Query not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ  : Invalid HTTP request pointer
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Query string truncated
+ */
+esp_err_t httpd_req_get_url_query_str(httpd_req_t *r, char *buf, size_t buf_len);
+
+/**
+ * @brief   Helper function to get a URL query tag from a query
+ *          string of the type param1=val1&param2=val2
+ *
+ * @note
+ *  - The components of URL query string (keys and values) are not URLdecoded.
+ *    The user must check for 'Content-Type' field in the request headers and
+ *    then depending upon the specified encoding (URLencoded or otherwise) apply
+ *    the appropriate decoding algorithm.
+ *  - If actual value size is greater than val_size, then the value is truncated,
+ *    accompanied by truncation error as return value.
+ *
+ * @param[in]  qry       Pointer to query string
+ * @param[in]  key       The key to be searched in the query string
+ * @param[out] val       Pointer to the buffer into which the value will be copied if the key is found
+ * @param[in]  val_size  Size of the user buffer "val"
+ *
+ * @return
+ *  - ESP_OK : Key is found in the URL query string and copied to buffer
+ *  - ESP_ERR_NOT_FOUND          : Key not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
+ */
+esp_err_t httpd_query_key_value(const char *qry, const char *key, char *val, size_t val_size);
+
+/**
+ * @brief   Get the value string of a cookie value from the "Cookie" request headers by cookie name.
+ *
+ * @param[in]       req             Pointer to the HTTP request
+ * @param[in]       cookie_name     The cookie name to be searched in the request
+ * @param[out]      val             Pointer to the buffer into which the value of cookie will be copied if the cookie is found
+ * @param[inout]    val_size        Pointer to size of the user buffer "val". This variable will contain cookie length if
+ *                                  ESP_OK is returned and required buffer length in case ESP_ERR_HTTPD_RESULT_TRUNC is returned.
+ *
+ * @return
+ *  - ESP_OK : Key is found in the cookie string and copied to buffer
+ *  - ESP_ERR_NOT_FOUND          : Key not found
+ *  - ESP_ERR_INVALID_ARG        : Null arguments
+ *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
+ *  - ESP_ERR_NO_MEM             : Memory allocation failure
+ */
+esp_err_t httpd_req_get_cookie_val(httpd_req_t *req, const char *cookie_name, char *val, size_t *val_size);
+
+/**
+ * @brief Test if a URI matches the given wildcard template.
+ *
+ * Template may end with '?' to make the previous character optional (typically a slash),
+ * '*' for a wildcard match, and '?*' to make the previous character optional, and if present,
+ * allow anything to follow.
+ *
+ * Example:
+ *   - * matches everything
+ *   - /api/? matches /api and /api/
+ *   - /api/\* (sans the backslash) matches /api/ and /api/status, but not /api or /ap
+ *   - /api/?* or /api/\*?  (sans the backslash) matches /api/, /api/status, and also /api, but not /apix or /ap
+ *
+ * The special characters '?' and '*' anywhere else in the template will be taken literally.
+ *
+ * @param[in] uri_template   URI template (pattern)
+ * @param[in] uri_to_match   URI to be matched
+ * @param[in] match_upto     how many characters of the URI buffer to test
+ *                          (there may be trailing query string etc.)
+ *
+ * @return true if a match was found
+ */
+bool httpd_uri_match_wildcard(const char *uri_template, const char *uri_to_match, size_t match_upto);
+
+/**
+ * @brief   API to send a complete HTTP response.
+ *
+ * This API will send the data as an HTTP response to the request.
+ * This assumes that you have the entire response ready in a single
+ * buffer. If you wish to send response in incremental chunks use
+ * httpd_resp_send_chunk() instead.
+ *
+ * If no status code and content-type were set, by default this
+ * will send 200 OK status code and content type as text/html.
+ * You may call the following functions before this API to configure
+ * the response headers :
+ *      httpd_resp_set_status() - for setting the HTTP status string,
+ *      httpd_resp_set_type()   - for setting the Content Type,
+ *      httpd_resp_set_hdr()    - for appending any additional field
+ *                                value entries in the response header
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, the request has been responded to.
+ *  - No additional data can then be sent for the request.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Buffer from where the content is to be fetched
+ * @param[in] buf_len   Length of the buffer, HTTPD_RESP_USE_STRLEN to use strlen()
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
+ */
+esp_err_t httpd_resp_send(httpd_req_t *r, const char *buf, ssize_t buf_len);
+
+/**
+ * @brief   API to send one HTTP chunk
+ *
+ * This API will send the data as an HTTP response to the
+ * request. This API will use chunked-encoding and send the response
+ * in the form of chunks. If you have the entire response contained in
+ * a single buffer, please use httpd_resp_send() instead.
+ *
+ * If no status code and content-type were set, by default this will
+ * send 200 OK status code and content type as text/html. You may
+ * call the following functions before this API to configure the
+ * response headers
+ *      httpd_resp_set_status() - for setting the HTTP status string,
+ *      httpd_resp_set_type()   - for setting the Content Type,
+ *      httpd_resp_set_hdr()    - for appending any additional field
+ *                                value entries in the response header
+ *
+ * @note
+ * - This API is supposed to be called only from the context of
+ *   a URI handler where httpd_req_t* request pointer is valid.
+ * - When you are finished sending all your chunks, you must call
+ *   this function with buf_len as 0.
+ * - Once this API is called, all request headers are purged, so
+ *   request headers need be copied into separate buffers if they
+ *   are required later.
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Pointer to a buffer that stores the data
+ * @param[in] buf_len   Length of the buffer, HTTPD_RESP_USE_STRLEN to use strlen()
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet chunk
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len);
+
+/**
+ * @brief   API to send a complete string as HTTP response.
+ *
+ * This API simply calls httpd_resp_send with buffer length
+ * set to string length assuming the buffer contains a null
+ * terminated string
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] str       String to be sent as response body
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
+ */
+static inline esp_err_t httpd_resp_sendstr(httpd_req_t *r, const char *str) {
+    return httpd_resp_send(r, str, (str == NULL) ? 0 : HTTPD_RESP_USE_STRLEN);
+}
+
+/**
+ * @brief   API to send a string as an HTTP response chunk.
+ *
+ * This API simply calls httpd_resp_send_chunk with buffer length
+ * set to string length assuming the buffer contains a null
+ * terminated string
+ *
+ * @param[in] r    The request being responded to
+ * @param[in] str  String to be sent as response body (NULL to finish response packet)
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null request pointer
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Essential headers are too large for internal buffer
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
+ */
+static inline esp_err_t httpd_resp_sendstr_chunk(httpd_req_t *r, const char *str) {
+    return httpd_resp_send_chunk(r, str, (str == NULL) ? 0 : HTTPD_RESP_USE_STRLEN);
+}
+
+/* Some commonly used status codes */
+#define HTTPD_200      "200 OK"                     /*!< HTTP Response 200 */
+#define HTTPD_204      "204 No Content"             /*!< HTTP Response 204 */
+#define HTTPD_207      "207 Multi-Status"           /*!< HTTP Response 207 */
+#define HTTPD_400      "400 Bad Request"            /*!< HTTP Response 400 */
+#define HTTPD_404      "404 Not Found"              /*!< HTTP Response 404 */
+#define HTTPD_408      "408 Request Timeout"        /*!< HTTP Response 408 */
+#define HTTPD_500      "500 Internal Server Error"  /*!< HTTP Response 500 */
+
+/**
+ * @brief   API to set the HTTP status code
+ *
+ * This API sets the status of the HTTP response to the value specified.
+ * By default, the '200 OK' response is sent as the response.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - This API only sets the status to this value. The status isn't
+ *    sent out until any of the send APIs is executed.
+ *  - Make sure that the lifetime of the status string is valid till
+ *    send function is called.
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] status    The HTTP status code of this response
+ *
+ * @return
+ *  - ESP_OK : On success
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_set_status(httpd_req_t *r, const char *status);
+
+/* Some commonly used content types */
+#define HTTPD_TYPE_JSON   "application/json"            /*!< HTTP Content type JSON */
+#define HTTPD_TYPE_TEXT   "text/html"                   /*!< HTTP Content type text/HTML */
+#define HTTPD_TYPE_OCTET  "application/octet-stream"    /*!< HTTP Content type octext-stream */
+
+/**
+ * @brief   API to set the HTTP content type
+ *
+ * This API sets the 'Content Type' field of the response.
+ * The default content type is 'text/html'.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - This API only sets the content type to this value. The type
+ *    isn't sent out until any of the send APIs is executed.
+ *  - Make sure that the lifetime of the type string is valid till
+ *    send function is called.
+ *
+ * @param[in] r     The request being responded to
+ * @param[in] type  The Content Type of the response
+ *
+ * @return
+ *  - ESP_OK   : On success
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_set_type(httpd_req_t *r, const char *type);
+
+/**
+ * @brief   API to append any additional headers
+ *
+ * This API sets any additional header fields that need to be sent in the response.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - The header isn't sent out until any of the send APIs is executed.
+ *  - The maximum allowed number of additional headers is limited to
+ *    value of max_resp_headers in config structure.
+ *  - Make sure that the lifetime of the field value strings are valid till
+ *    send function is called.
+ *
+ * @param[in] r     The request being responded to
+ * @param[in] field The field name of the HTTP header
+ * @param[in] value The value of this HTTP header
+ *
+ * @return
+ *  - ESP_OK : On successfully appending new header
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_HDR    : Total additional headers exceed max allowed
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_set_hdr(httpd_req_t *r, const char *field, const char *value);
+
+/**
+ * @brief   For sending out error code in response to HTTP request.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *  - If you wish to send additional data in the body of the
+ *    response, please use the lower-level functions directly.
+ *
+ * @param[in] req     Pointer to the HTTP request for which the response needs to be sent
+ * @param[in] error   Error type to send
+ * @param[in] msg     Error message string (pass NULL for default message)
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_send_err(httpd_req_t *req, httpd_err_code_t error, const char *msg);
+
+/**
+ * @brief   For sending out custom error code in response to HTTP request.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *  - If you wish to send additional data in the body of the
+ *    response, please use the lower-level functions directly.
+ *
+ * @param[in] req     Pointer to the HTTP request for which the response needs to be sent
+ * @param[in] status  Error status to send
+ * @param[in] msg     Error message string
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+esp_err_t httpd_resp_send_custom_err(httpd_req_t *req, const char *status, const char *msg);
+
+/**
+ * @brief   Helper function for HTTP 404
+ *
+ * Send HTTP 404 message. If you wish to send additional data in the body of the
+ * response, please use the lower-level functions directly.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r The request being responded to
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+static inline esp_err_t httpd_resp_send_404(httpd_req_t *r) {
+    return httpd_resp_send_err(r, HTTPD_404_NOT_FOUND, NULL);
+}
+
+/**
+ * @brief   Helper function for HTTP 408
+ *
+ * Send HTTP 408 message. If you wish to send additional data in the body of the
+ * response, please use the lower-level functions directly.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r The request being responded to
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+static inline esp_err_t httpd_resp_send_408(httpd_req_t *r) {
+    return httpd_resp_send_err(r, HTTPD_408_REQ_TIMEOUT, NULL);
+}
+
+/**
+ * @brief   Helper function for HTTP 500
+ *
+ * Send HTTP 500 message. If you wish to send additional data in the body of the
+ * response, please use the lower-level functions directly.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Once this API is called, all request headers are purged, so
+ *    request headers need be copied into separate buffers if
+ *    they are required later.
+ *
+ * @param[in] r The request being responded to
+ *
+ * @return
+ *  - ESP_OK : On successfully sending the response packet
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ *  - ESP_ERR_HTTPD_RESP_SEND   : Error in raw send
+ *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request pointer
+ */
+static inline esp_err_t httpd_resp_send_500(httpd_req_t *r) {
+    return httpd_resp_send_err(r, HTTPD_500_INTERNAL_SERVER_ERROR, NULL);
+}
+
+/**
+ * @brief   Raw HTTP send
+ *
+ * Call this API if you wish to construct your custom response packet.
+ * When using this, all essential header, eg. HTTP version, Status Code,
+ * Content Type and Length, Encoding, etc. will have to be constructed
+ * manually, and HTTP delimiters (CRLF) will need to be placed correctly
+ * for separating sub-sections of the HTTP response packet.
+ *
+ * If the send override function is set, this API will end up
+ * calling that function eventually to send data out.
+ *
+ * @note
+ *  - This API is supposed to be called only from the context of
+ *    a URI handler where httpd_req_t* request pointer is valid.
+ *  - Unless the response has the correct HTTP structure (which the
+ *    user must now ensure) it is not guaranteed that it will be
+ *    recognized by the client. For most cases, you wouldn't have
+ *    to call this API, but you would rather use either of :
+ *          httpd_resp_send(),
+ *          httpd_resp_send_chunk()
+ *
+ * @param[in] r         The request being responded to
+ * @param[in] buf       Buffer from where the fully constructed packet is to be read
+ * @param[in] buf_len   Length of the buffer
+ *
+ * @return
+ *  - Bytes : Number of bytes that were sent successfully
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket send()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket send()
+ */
+int httpd_send(httpd_req_t *r, const char *buf, size_t buf_len);
+
+/**
+ * A low level API to send data on a given socket
+ *
+ * @note This API is not recommended to be used in any request handler.
+ * Use this only for advanced use cases, wherein some asynchronous
+ * data is to be sent over a socket.
+ *
+ * This internally calls the default send function, or the function registered by
+ * httpd_sess_set_send_override().
+ *
+ * @param[in] hd        server instance
+ * @param[in] sockfd    session socket file descriptor
+ * @param[in] buf       buffer with bytes to send
+ * @param[in] buf_len   data size
+ * @param[in] flags     flags for the send() function
+ * @return
+ *  - Bytes : The number of bytes sent successfully
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket send()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket send()
+ */
+int httpd_socket_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags);
+
+/**
+ * A low level API to receive data from a given socket
+ *
+ * @note This API is not recommended to be used in any request handler.
+ * Use this only for advanced use cases, wherein some asynchronous
+ * communication is required.
+ *
+ * This internally calls the default recv function, or the function registered by
+ * httpd_sess_set_recv_override().
+ *
+ * @param[in] hd        server instance
+ * @param[in] sockfd    session socket file descriptor
+ * @param[in] buf       buffer with bytes to send
+ * @param[in] buf_len   data size
+ * @param[in] flags     flags for the send() function
+ * @return
+ *  - Bytes : The number of bytes received successfully
+ *  - 0     : Buffer length parameter is zero / connection closed by peer
+ *  - HTTPD_SOCK_ERR_INVALID  : Invalid arguments
+ *  - HTTPD_SOCK_ERR_TIMEOUT  : Timeout/interrupted while calling socket recv()
+ *  - HTTPD_SOCK_ERR_FAIL     : Unrecoverable error while calling socket recv()
+ */
+int httpd_socket_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
+
+/** End of Request / Response
+ * @}
+ */
+
+/* ************** Group: Session ************** */
+/** @name Session
+ * Functions for controlling sessions and accessing context data
+ * @{
+ */
+
+/**
+ * @brief   Get session context from socket descriptor
+ *
+ * Typically if a session context is created, it is available to URI handlers
+ * through the httpd_req_t structure. But, there are cases where the web
+ * server's send/receive functions may require the context (for example, for
+ * accessing keying information etc). Since the send/receive function only have
+ * the socket descriptor at their disposal, this API provides them with a way to
+ * retrieve the session context.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ *
+ * @return
+ *  - void* : Pointer to the context associated with this session
+ *  - NULL  : Empty context / Invalid handle / Invalid socket fd
+ */
+void *httpd_sess_get_ctx(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Set session context by socket descriptor
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ * @param[in] ctx       Context object to assign to the session
+ * @param[in] free_fn   Function that should be called to free the context
+ */
+void httpd_sess_set_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn);
+
+/**
+ * @brief   Get session 'transport' context by socket descriptor
+ * @see     httpd_sess_get_ctx()
+ *
+ * This context is used by the send/receive functions, for example to manage SSL context.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ * @return
+ *  - void* : Pointer to the transport context associated with this session
+ *  - NULL  : Empty context / Invalid handle / Invalid socket fd
+ */
+void *httpd_sess_get_transport_ctx(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Set session 'transport' context by socket descriptor
+ * @see     httpd_sess_set_ctx()
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor for which the context should be extracted.
+ * @param[in] ctx       Transport context object to assign to the session
+ * @param[in] free_fn   Function that should be called to free the transport context
+ */
+void httpd_sess_set_transport_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn);
+
+/**
+ * @brief   Get HTTPD global user context (it was set in the server config struct)
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @return global user context
+ */
+void *httpd_get_global_user_ctx(httpd_handle_t handle);
+
+/**
+ * @brief   Get HTTPD global transport context (it was set in the server config struct)
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @return global transport context
+ */
+void *httpd_get_global_transport_ctx(httpd_handle_t handle);
+
+/**
+ * @brief   Trigger an httpd session close externally
+ *
+ * @note    Calling this API is only required in special circumstances wherein
+ *          some application requires to close an httpd client session asynchronously.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor of the session to be closed
+ *
+ * @return
+ *  - ESP_OK    : On successfully initiating closure
+ *  - ESP_FAIL  : Failure to queue work
+ *  - ESP_ERR_NOT_FOUND   : Socket fd not found
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_trigger_close(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Update LRU counter for a given socket
+ *
+ * LRU Counters are internally associated with each session to monitor
+ * how recently a session exchanged traffic. When LRU purge is enabled,
+ * if a client is requesting for connection but maximum number of
+ * sockets/sessions is reached, then the session having the earliest
+ * LRU counter is closed automatically.
+ *
+ * Updating the LRU counter manually prevents the socket from being purged
+ * due to the Least Recently Used (LRU) logic, even though it might not
+ * have received traffic for some time. This is useful when all open
+ * sockets/session are frequently exchanging traffic but the user specifically
+ * wants one of the sessions to be kept open, irrespective of when it last
+ * exchanged a packet.
+ *
+ * @note    Calling this API is only necessary if the LRU Purge Enable option
+ *          is enabled.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] sockfd    The socket descriptor of the session for which LRU counter
+ *                      is to be updated
+ *
+ * @return
+ *  - ESP_OK : Socket found and LRU counter updated
+ *  - ESP_ERR_NOT_FOUND   : Socket not found
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_update_lru_counter(httpd_handle_t handle, int sockfd);
+
+/**
+ * @brief   Returns list of current socket descriptors of active sessions
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in,out] fds   In: Size of provided client_fds array
+ *                      Out: Number of valid client fds returned in client_fds,
+ * @param[out] client_fds  Array of client fds
+ *
+ * @note Size of provided array has to be equal or greater then maximum number of opened
+ *       sockets, configured upon initialization with max_open_sockets field in
+ *       httpd_config_t structure.
+ *
+ * @return
+ *  - ESP_OK              : Successfully retrieved session list
+ *  - ESP_ERR_INVALID_ARG : Wrong arguments or list is longer than provided array
+ */
+esp_err_t httpd_get_client_list(httpd_handle_t handle, size_t *fds, int *client_fds);
+
+/** End of Session
+ * @}
+ */
+
+/* ************** Group: Work Queue ************** */
+/** @name Work Queue
+ * APIs related to the HTTPD Work Queue
+ * @{
+ */
+
+/**
+ * @brief   Prototype of the HTTPD work function
+ *          Please refer to httpd_queue_work() for more details.
+ * @param[in] arg   The arguments for this work function
+ */
+typedef void (*httpd_work_fn_t)(void *arg);
+
+/**
+ * @brief   Queue execution of a function in HTTPD's context
+ *
+ * This API queues a work function for asynchronous execution
+ *
+ * @note    Some protocols require that the web server generate some asynchronous data
+ *          and send it to the persistently opened connection. This facility is for use
+ *          by such protocols.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] work      Pointer to the function to be executed in the HTTPD's context
+ * @param[in] arg       Pointer to the arguments that should be passed to this function
+ *
+ * @return
+ *  - ESP_OK   : On successfully queueing the work
+ *  - ESP_FAIL : Failure in ctrl socket
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_queue_work(httpd_handle_t handle, httpd_work_fn_t work, void *arg);
+
+/** End of Group Work Queue
+ * @}
+ */
+
+/* ************** Group: WebSocket ************** */
+/** @name WebSocket
+ * Functions and structs for WebSocket server
+ * @{
+ */
+#if CONFIG_HTTPD_WS_SUPPORT || __DOXYGEN__
+/**
+ * @brief Enum for WebSocket packet types (Opcode in the header)
+ * @note Please refer to RFC6455 Section 5.4 for more details
+ */
+typedef enum {
+    HTTPD_WS_TYPE_CONTINUE   = 0x0,
+    HTTPD_WS_TYPE_TEXT       = 0x1,
+    HTTPD_WS_TYPE_BINARY     = 0x2,
+    HTTPD_WS_TYPE_CLOSE      = 0x8,
+    HTTPD_WS_TYPE_PING       = 0x9,
+    HTTPD_WS_TYPE_PONG       = 0xA
+} httpd_ws_type_t;
+
+/**
+ * @brief Enum for client info description
+ */
+typedef enum {
+    HTTPD_WS_CLIENT_INVALID        = 0x0,
+    HTTPD_WS_CLIENT_HTTP           = 0x1,
+    HTTPD_WS_CLIENT_WEBSOCKET      = 0x2,
+} httpd_ws_client_info_t;
+
+/**
+ * @brief WebSocket frame format
+ */
+typedef struct httpd_ws_frame {
+    bool final;                 /*!< Final frame:
+                                     For received frames this field indicates whether the `FIN` flag was set.
+                                     For frames to be transmitted, this field is only used if the `fragmented`
+                                         option is set as well. If `fragmented` is false, the `FIN` flag is set
+                                         by default, marking the ws_frame as a complete/unfragmented message
+                                         (esp_http_server doesn't automatically fragment messages) */
+    bool fragmented;            /*!< Indication that the frame allocated for transmission is a message fragment,
+                                     so the `FIN` flag is set manually according to the `final` option.
+                                     This flag is never set for received messages */
+    httpd_ws_type_t type;       /*!< WebSocket frame type */
+    uint8_t *payload;           /*!< Pre-allocated data buffer */
+    size_t len;                 /*!< Length of the WebSocket data */
+} httpd_ws_frame_t;
+
+/**
+ * @brief Transfer complete callback
+ */
+typedef void (*transfer_complete_cb)(esp_err_t err, int socket, void *arg);
+
+/**
+ * @brief Receive and parse a WebSocket frame
+ *
+ * @note    Calling httpd_ws_recv_frame() with max_len as 0 will give actual frame size in pkt->len.
+ *          The user can dynamically allocate space for pkt->payload as per this length and call httpd_ws_recv_frame() again to get the actual data.
+ *          Please refer to the corresponding example for usage.
+ *
+ * @param[in]   req         Current request
+ * @param[out]  pkt         WebSocket packet
+ * @param[in]   max_len     Maximum length for receive
+ * @return
+ *  - ESP_OK                    : On successful
+ *  - ESP_FAIL                  : Socket errors occurs
+ *  - ESP_ERR_INVALID_STATE     : Handshake was already done beforehand
+ *  - ESP_ERR_INVALID_ARG       : Argument is invalid (null or non-WebSocket)
+ */
+esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *pkt, size_t max_len);
+
+/**
+ * @brief Construct and send a WebSocket frame
+ * @param[in]   req     Current request
+ * @param[in]   pkt     WebSocket frame
+ * @return
+ *  - ESP_OK                    : On successful
+ *  - ESP_FAIL                  : When socket errors occurs
+ *  - ESP_ERR_INVALID_STATE     : Handshake was already done beforehand
+ *  - ESP_ERR_INVALID_ARG       : Argument is invalid (null or non-WebSocket)
+ */
+esp_err_t httpd_ws_send_frame(httpd_req_t *req, httpd_ws_frame_t *pkt);
+
+/**
+ * @brief Low level send of a WebSocket frame out of the scope of current request
+ * using internally configured httpd send function
+ *
+ * This API should rarely be called directly, with an exception of asynchronous send using httpd_queue_work.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] fd      Socket descriptor for sending data
+ * @param[in] frame     WebSocket frame
+ * @return
+ *  - ESP_OK                    : On successful
+ *  - ESP_FAIL                  : When socket errors occurs
+ *  - ESP_ERR_INVALID_STATE     : Handshake was already done beforehand
+ *  - ESP_ERR_INVALID_ARG       : Argument is invalid (null or non-WebSocket)
+ */
+esp_err_t httpd_ws_send_frame_async(httpd_handle_t hd, int fd, httpd_ws_frame_t *frame);
+
+/**
+ * @brief Checks the supplied socket descriptor if it belongs to any active client
+ * of this server instance and if the websoket protocol is active
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] fd      Socket descriptor
+ * @return
+ *  - HTTPD_WS_CLIENT_INVALID   : This fd is not a client of this httpd
+ *  - HTTPD_WS_CLIENT_HTTP      : This fd is an active client, protocol is not WS
+ *  - HTTPD_WS_CLIENT_WEBSOCKET : This fd is an active client, protocol is WS
+ */
+httpd_ws_client_info_t httpd_ws_get_fd_info(httpd_handle_t hd, int fd);
+
+/**
+ * @brief Sends data to to specified websocket synchronously
+ *
+ * @param[in] handle  Server instance data
+ * @param[in] socket  Socket descriptor
+ * @param[in] frame   Websocket frame
+ * @return
+ *  - ESP_OK                    : On successful
+ *  - ESP_FAIL                  : When socket errors occurs
+ *  - ESP_ERR_NO_MEM            : Unable to allocate memory
+ */
+esp_err_t httpd_ws_send_data(httpd_handle_t handle, int socket, httpd_ws_frame_t *frame);
+
+/**
+ * @brief Sends data to to specified websocket asynchronously
+ *
+ * @param[in] handle    Server instance data
+ * @param[in] socket    Socket descriptor
+ * @param[in] frame     Websocket frame
+ * @param[in] callback  Callback invoked after sending data
+ * @param[in] arg       User data passed to provided callback
+ * @return
+ *  - ESP_OK                    : On successful
+ *  - ESP_FAIL                  : When socket errors occurs
+ *  - ESP_ERR_NO_MEM            : Unable to allocate memory
+ */
+esp_err_t httpd_ws_send_data_async(httpd_handle_t handle, int socket, httpd_ws_frame_t *frame,
+                                   transfer_complete_cb callback, void *arg);
+
+#endif /* CONFIG_HTTPD_WS_SUPPORT || __DOXYGEN__ */
+/** End of WebSocket related stuff
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _ESP_HTTP_SERVER_H_ */

--- a/components/esp_http_server/src/esp_httpd_priv.h
+++ b/components/esp_http_server/src/esp_httpd_priv.h
@@ -1,0 +1,572 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef _HTTPD_PRIV_H_
+#define _HTTPD_PRIV_H_
+
+#include <stdbool.h>
+#include <sys/socket.h>
+#include <sys/param.h>
+#include <netinet/in.h>
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <esp_http_server.h>
+#include "osal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if CONFIG_NEWLIB_NANO_FORMAT
+#define NEWLIB_NANO_COMPAT_FORMAT            PRIu32
+#define NEWLIB_NANO_COMPAT_CAST(size_t_var)  (uint32_t)size_t_var
+#else
+#define NEWLIB_NANO_COMPAT_FORMAT            "zu"
+#define NEWLIB_NANO_COMPAT_CAST(size_t_var)  size_t_var
+#endif
+
+/* Size of request data block/chunk (not to be confused with chunked encoded data)
+ * that is received and parsed in one turn of the parsing process. */
+#define PARSER_BLOCK_SIZE  128
+
+/* Formats a log string to prepend context function name */
+#define LOG_FMT(x)      "%s: " x, __func__
+
+/**
+ * @brief Thread related data for internal use
+ */
+struct thread_data {
+    othread_t handle;   /*!< Handle to thread/task */
+    enum {
+        THREAD_IDLE = 0,
+        THREAD_RUNNING,
+        THREAD_STOPPING,
+        THREAD_STOPPED,
+    } status;           /*!< State of the thread */
+};
+
+/**
+ * @brief A database of all the open sockets in the system.
+ */
+struct sock_db {
+    int fd;                                 /*!< The file descriptor for this socket */
+    void *ctx;                              /*!< A custom context for this socket */
+    bool ignore_sess_ctx_changes;           /*!< Flag indicating if session context changes should be ignored */
+    void *transport_ctx;                    /*!< A custom 'transport' context for this socket, to be used by send/recv/pending */
+    httpd_handle_t handle;                  /*!< Server handle */
+    httpd_free_ctx_fn_t free_ctx;      /*!< Function for freeing the context */
+    httpd_free_ctx_fn_t free_transport_ctx; /*!< Function for freeing the 'transport' context */
+    httpd_send_func_t send_fn;              /*!< Send function for this socket */
+    httpd_recv_func_t recv_fn;              /*!< Receive function for this socket */
+    httpd_pending_func_t pending_fn;        /*!< Pending function for this socket */
+    uint64_t lru_counter;                   /*!< LRU Counter indicating when the socket was last used */
+    bool lru_socket;                        /*!< Flag indicating LRU socket */
+    char pending_data[PARSER_BLOCK_SIZE];   /*!< Buffer for pending data to be received */
+    size_t pending_len;                     /*!< Length of pending data to be received */
+    bool for_async_req;                     /*!< If true, the socket will not be LRU purged */
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+    bool ws_handshake_done;                 /*!< True if it has done WebSocket handshake (if this socket is a valid WS) */
+    bool ws_close;                          /*!< Set to true to close the socket later (when WS Close frame received) */
+    esp_err_t (*ws_handler)(httpd_req_t *r);   /*!< WebSocket handler, leave to null if it's not WebSocket */
+    bool ws_control_frames;                         /*!< WebSocket flag indicating that control frames should be passed to user handlers */
+    void *ws_user_ctx;                         /*!< Pointer to user context data which will be available to handler for websocket*/
+#endif
+};
+
+/**
+ * @brief   Auxiliary data structure for use during reception and processing
+ *          of requests and temporarily keeping responses
+ */
+struct httpd_req_aux {
+    struct sock_db *sd;                             /*!< Pointer to socket database */
+    char           *scratch;                        /*!< Temporary buffer for our operations (1 byte extra for null termination) */
+    size_t          scratch_size_limit;             /*!< Scratch buffer size limit (By default this value is set to CONFIG_HTTPD_MAX_REQ_HDR_LEN, overwrite is possible) */
+    size_t          scratch_cur_size;               /*!< Scratch buffer cur size (By default this value is set to CONFIG_HTTPD_MAX_URI_LEN, overwrite is possible) */
+    size_t          max_req_hdr_len;             /*!< Header buffer size limit */
+    size_t          max_uri_len;             /*!< URI buffer size limit */
+    size_t          remaining_len;                  /*!< Amount of data remaining to be fetched */
+    char           *status;                         /*!< HTTP response's status code */
+    char           *content_type;                   /*!< HTTP response's content type */
+    bool            first_chunk_sent;               /*!< Used to indicate if first chunk sent */
+    unsigned        req_hdrs_count;                 /*!< Count of total headers in request packet */
+    unsigned        resp_hdrs_count;                /*!< Count of additional headers in response packet */
+    struct resp_hdr {
+        const char *field;
+        const char *value;
+    } *resp_hdrs;                                   /*!< Additional headers in response packet */
+    struct http_parser_url url_parse_res;           /*!< URL parsing result, used for retrieving URL elements */
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+    bool ws_handshake_detect;                       /*!< WebSocket handshake detection flag */
+    httpd_ws_type_t ws_type;                        /*!< WebSocket frame type */
+    bool ws_final;                                  /*!< WebSocket FIN bit (final frame or not) */
+    uint8_t mask_key[4];                            /*!< WebSocket mask key for this payload */
+#endif
+};
+
+/**
+ * @brief   Server data for each instance. This is exposed publicly as
+ *          httpd_handle_t but internal structure/members are kept private.
+ */
+struct httpd_data {
+    httpd_config_t config;                  /*!< HTTPD server configuration */
+    int listen_fd;                          /*!< Server listener FD */
+    int ctrl_fd;                            /*!< Ctrl message receiver FD */
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+    SemaphoreHandle_t ctrl_sock_semaphore;  /*!< Ctrl socket semaphore */
+#endif
+    int msg_fd;                             /*!< Ctrl message sender FD */
+    struct thread_data hd_td;               /*!< Information for the HTTPD thread */
+    struct sock_db *hd_sd;                  /*!< The socket database */
+    int hd_sd_active_count;                 /*!< The number of the active sockets */
+    httpd_uri_t **hd_calls;                 /*!< Registered URI handlers */
+    struct httpd_req hd_req;                /*!< The current HTTPD request */
+    struct httpd_req_aux hd_req_aux;        /*!< Additional data about the HTTPD request kept unexposed */
+    uint64_t lru_counter;                   /*!< LRU counter */
+
+    /* Array of registered error handler functions */
+    httpd_err_handler_func_t *err_handler_fns;
+};
+
+/******************* Group : Session Management ********************/
+/** @name Session Management
+ * Functions related to HTTP session management
+ * @{
+ */
+
+// Enum function, which will be called for each session
+typedef int (*httpd_session_enum_function)(struct sock_db *session, void *context);
+
+/**
+ * @brief  Enumerates all sessions
+ *
+ * @param[in] hd            Server instance data
+ * @param[in] enum_function Enumeration function, which will be called for each session
+ * @param[in] context       Context, which will be passed to the enumeration function
+ */
+void httpd_sess_enum(struct httpd_data *hd, httpd_session_enum_function enum_function, void *context);
+
+/**
+ * @brief   Returns next free session slot (fd<0)
+ *
+ * @param[in] hd    Server instance data
+ *
+ * @return
+ *  - +VE : Free session slot
+ *  - NULL: End of iteration
+ */
+struct sock_db *httpd_sess_get_free(struct httpd_data *hd);
+
+/**
+ * @brief Retrieve a session by its descriptor
+ *
+ * @param[in] hd     Server instance data
+ * @param[in] sockfd Socket FD
+ * @return pointer into the socket DB, or NULL if not found
+ */
+struct sock_db *httpd_sess_get(struct httpd_data *hd, int sockfd);
+
+/**
+ * @brief Delete sessions whose FDs have became invalid.
+ *        This is a recovery strategy e.g. after select() fails.
+ *
+ * @param[in] hd    Server instance data
+ */
+void httpd_sess_delete_invalid(struct httpd_data *hd);
+
+/**
+ * @brief   Initializes an http session by resetting the sockets database.
+ *
+ * @param[in] hd    Server instance data
+ */
+void httpd_sess_init(struct httpd_data *hd);
+
+/**
+ * @brief   Starts a new session for client requesting connection and adds
+ *          it's descriptor to the socket database.
+ *
+ * @param[in] hd    Server instance data
+ * @param[in] newfd Descriptor of the new client to be added to the session.
+ *
+ * @return
+ *  - ESP_OK   : on successfully queuing the work
+ *  - ESP_FAIL : in case of control socket error while sending
+ */
+esp_err_t httpd_sess_new(struct httpd_data *hd, int newfd);
+
+/**
+ * @brief   Processes incoming HTTP requests
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] session Session
+ *
+ * @return
+ *  - ESP_OK    : on successfully receiving, parsing and responding to a request
+ *  - ESP_FAIL  : in case of failure in any of the stages of processing
+ */
+esp_err_t httpd_sess_process(struct httpd_data *hd, struct sock_db *session);
+
+/**
+ * @brief   Remove client descriptor from the session / socket database
+ *          and close the connection for this client.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] session Session
+ */
+void httpd_sess_delete(struct httpd_data *hd, struct sock_db *session);
+
+/**
+ * @brief   Free session context
+ *
+ * @param[in] ctx     Pointer to session context
+ * @param[in] free_fn Free function to call on session context
+ */
+void httpd_sess_free_ctx(void **ctx, httpd_free_ctx_fn_t free_fn);
+
+/**
+ * @brief   Add descriptors present in the socket database to an fdset and
+ *          update the value of maxfd which are needed by the select function
+ *          for looking through all available sockets for incoming data.
+ *
+ * @param[in]  hd    Server instance data
+ * @param[out] fdset File descriptor set to be updated.
+ * @param[out] maxfd Maximum value among all file descriptors.
+ */
+void httpd_sess_set_descriptors(struct httpd_data *hd, fd_set *fdset, int *maxfd);
+
+/**
+ * @brief   Checks if session can accept another connection from new client.
+ *          If sockets database is full then this returns false.
+ *
+ * @param[in] hd  Server instance data
+ *
+ * @return True if session can accept new clients
+ */
+bool httpd_is_sess_available(struct httpd_data *hd);
+
+/**
+ * @brief   Checks if session has any pending data/packets
+ *          for processing
+ *
+ * This is needed as httpd_unrecv may un-receive next
+ * packet in the stream. If only partial packet was
+ * received then select() would mark the fd for processing
+ * as remaining part of the packet would still be in socket
+ * recv queue. But if a complete packet got unreceived
+ * then it would not be processed until further data is
+ * received on the socket. This is when this function
+ * comes in use, as it checks the socket's pending data
+ * buffer.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] session Session
+ *
+ * @return True if there is any pending data
+ */
+bool httpd_sess_pending(struct httpd_data *hd, struct sock_db *session);
+
+/**
+ * @brief   Removes the least recently used client from the session
+ *
+ * This may be useful if new clients are requesting for connection but
+ * max number of connections is reached, in which case the client which
+ * is inactive for the longest will be removed from the session.
+ *
+ * @param[in] hd  Server instance data
+ *
+ * @return
+ *  - ESP_OK    : if session closure initiated successfully
+ *  - ESP_FAIL  : if failed
+ */
+esp_err_t httpd_sess_close_lru(struct httpd_data *hd);
+
+/**
+ * @brief   Closes all sessions
+ *
+ * @param[in] hd  Server instance data
+ *
+ */
+void httpd_sess_close_all(struct httpd_data *hd);
+
+/** End of Group : Session Management
+ * @}
+ */
+
+/****************** Group : URI Handling ********************/
+/** @name URI Handling
+ * Methods for accessing URI handlers
+ * @{
+ */
+
+/**
+ * @brief   For an HTTP request, searches through all the registered URI handlers
+ *          and invokes the appropriate one if found
+ *
+ * @param[in] hd  Server instance data for which handler needs to be invoked
+ *
+ * @return
+ *  - ESP_OK    : if handler found and executed successfully
+ *  - ESP_FAIL  : otherwise
+ */
+esp_err_t httpd_uri(struct httpd_data *hd);
+
+/**
+ * @brief   Unregister all URI handlers
+ *
+ * @param[in] hd  Server instance data
+ */
+void httpd_unregister_all_uri_handlers(struct httpd_data *hd);
+
+/**
+ * @brief   Validates the request to prevent users from calling APIs, that are to
+ *          be called only inside a URI handler, outside the handler context
+ *
+ * @param[in] req Pointer to HTTP request that needs to be validated
+ *
+ * @return
+ *  - true  : if valid request
+ *  - false : otherwise
+ */
+bool httpd_validate_req_ptr(httpd_req_t *r);
+
+/* httpd_validate_req_ptr() adds some overhead to frequently used APIs,
+ * and is useful mostly for debugging, so it's preferable to disable
+ * the check by default and enable it only if necessary */
+#ifdef CONFIG_HTTPD_VALIDATE_REQ
+#define httpd_valid_req(r)  httpd_validate_req_ptr(r)
+#else
+#define httpd_valid_req(r)  true
+#endif
+
+/** End of Group : URI Handling
+ * @}
+ */
+
+/****************** Group : Processing ********************/
+/** @name Processing
+ * Methods for processing HTTP requests
+ * @{
+ */
+
+/**
+ * @brief   Initiates the processing of HTTP request
+ *
+ * Receives incoming TCP packet on a socket, then parses the packet as
+ * HTTP request and fills httpd_req_t data structure with the extracted
+ * URI, headers are ready to be fetched from scratch buffer and calling
+ * http_recv() after this reads the body of the request.
+ *
+ * @param[in] hd  Server instance data
+ * @param[in] sd  Pointer to socket which is needed for receiving TCP packets.
+ *
+ * @return
+ *  - ESP_OK    : if request packet is valid
+ *  - ESP_FAIL  : otherwise
+ */
+esp_err_t httpd_req_new(struct httpd_data *hd, struct sock_db *sd);
+
+/**
+ * @brief   For an HTTP request, resets the resources allocated for it and
+ *          purges any data left to be received
+ *
+ * @param[in] hd  Server instance data
+ *
+ * @return
+ *  - ESP_OK    : if request packet deleted and resources cleaned.
+ *  - ESP_FAIL  : otherwise.
+ */
+esp_err_t httpd_req_delete(struct httpd_data *hd);
+
+/**
+ * @brief   For handling HTTP errors by invoking registered
+ *          error handler function
+ *
+ * @param[in] req     Pointer to the HTTP request for which error occurred
+ * @param[in] error   Error type
+ *
+ * @return
+ *  - ESP_OK    : error handled successful
+ *  - ESP_FAIL  : failure indicates that the underlying socket needs to be closed
+ */
+esp_err_t httpd_req_handle_err(httpd_req_t *req, httpd_err_code_t error);
+
+/** End of Group : Parsing
+ * @}
+ */
+
+/****************** Group : Send/Receive ********************/
+/** @name Send and Receive
+ * Methods for transmitting and receiving HTTP requests and responses
+ * @{
+ */
+
+/**
+ * @brief   For sending out data in response to an HTTP request.
+ *
+ * @param[in] req     Pointer to the HTTP request for which the response needs to be sent
+ * @param[in] buf     Pointer to the buffer from where the body of the response is taken
+ * @param[in] buf_len Length of the buffer
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - ESP_FAIL       : if failed
+ */
+int httpd_send(httpd_req_t *req, const char *buf, size_t buf_len);
+
+/**
+ * @brief   For receiving HTTP request data
+ *
+ * @note    The exposed API httpd_recv() is simply this function with last parameter
+ *          set as false. This function is used internally during reception and
+ *          processing of a new request. The option to halt after receiving pending
+ *          data prevents the server from requesting more data than is needed for
+ *          completing a packet in case when all the remaining part of the packet is
+ *          in the pending buffer.
+ *
+ * @param[in]  req    Pointer to new HTTP request which only has the socket descriptor
+ * @param[out] buf    Pointer to the buffer which will be filled with the received data
+ * @param[in] buf_len Length of the buffer
+ * @param[in] halt_after_pending When set true, halts immediately after receiving from
+ *                               pending buffer
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - ESP_FAIL       : if failed
+ */
+int httpd_recv_with_opt(httpd_req_t *r, char *buf, size_t buf_len, bool halt_after_pending);
+
+/**
+ * @brief   For un-receiving HTTP request data
+ *
+ * This function copies data into internal buffer pending_data so that
+ * when httpd_recv is called, it first fetches this pending data and
+ * then only starts receiving from the socket
+ *
+ * @note    If data is too large for the internal buffer then only
+ *          part of the data is unreceived, reflected in the returned
+ *          length. Make sure that such truncation is checked for and
+ *          handled properly.
+ *
+ * @param[in] req     Pointer to new HTTP request which only has the socket descriptor
+ * @param[in] buf     Pointer to the buffer from where data needs to be un-received
+ * @param[in] buf_len Length of the buffer
+ *
+ * @return  Length of data copied into pending buffer
+ */
+size_t httpd_unrecv(struct httpd_req *r, const char *buf, size_t buf_len);
+
+/**
+ * @brief   This is the low level default send function of the HTTPD. This should
+ *          NEVER be called directly. The semantics of this is exactly similar to
+ *          send() of the BSD socket API.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] sockfd  Socket descriptor for sending data
+ * @param[in] buf     Pointer to the buffer from where the body of the response is taken
+ * @param[in] buf_len Length of the buffer
+ * @param[in] flags   Flags for mode selection
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - -1             : if failed (appropriate errno is set)
+ */
+int httpd_default_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags);
+
+/**
+ * @brief   This is the low level default recv function of the HTTPD. This should
+ *          NEVER be called directly. The semantics of this is exactly similar to
+ *          recv() of the BSD socket API.
+ *
+ * @param[in] hd      Server instance data
+ * @param[in] sockfd  Socket descriptor for sending data
+ * @param[out] buf    Pointer to the buffer which will be filled with the received data
+ * @param[in] buf_len Length of the buffer
+ * @param[in] flags   Flags for mode selection
+ *
+ * @return
+ *  - Length of data : if successful
+ *  - -1             : if failed (appropriate errno is set)
+ */
+int httpd_default_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
+
+/** End of Group : Send and Receive
+ * @}
+ */
+
+/* ************** Group: WebSocket ************** */
+/** @name WebSocket
+ * Functions for WebSocket header parsing
+ * @{
+ */
+
+
+/**
+ * @brief   This function is for responding a WebSocket handshake
+ *
+ * @param[in] req                       Pointer to handshake request that will be handled
+ * @param[in] supported_subprotocol     Pointer to the subprotocol supported by this URI
+ * @return
+ *  - ESP_OK                        : When handshake is successful
+ *  - ESP_ERR_NOT_FOUND             : When some headers (Sec-WebSocket-*) are not found
+ *  - ESP_ERR_INVALID_VERSION       : The WebSocket version is not "13"
+ *  - ESP_ERR_INVALID_STATE         : Handshake was done beforehand
+ *  - ESP_ERR_INVALID_ARG           : Argument is invalid (null or non-WebSocket)
+ *  - ESP_FAIL                      : Socket failures
+ */
+esp_err_t httpd_ws_respond_server_handshake(httpd_req_t *req, const char *supported_subprotocol);
+
+/**
+ * @brief   This function is for getting a frame type
+ *          and responding a WebSocket control frame automatically
+ *
+ * @param[in] req    Pointer to handshake request that will be handled
+ * @return
+ *  - ESP_OK                        : When handshake is successful
+ *  - ESP_ERR_INVALID_ARG           : Argument is invalid (null or non-WebSocket)
+ *  - ESP_ERR_INVALID_STATE         : Received only some parts of a control frame
+ *  - ESP_FAIL                      : Socket failures
+ */
+esp_err_t httpd_ws_get_frame_type(httpd_req_t *req);
+
+/**
+ * @brief   Trigger an httpd session close externally
+ *
+ * @note    Calling this API is only required in special circumstances wherein
+ *          some application requires to close an httpd client session asynchronously.
+ *
+ * @param[in] handle    Handle to server returned by httpd_start
+ * @param[in] session   Session to be closed
+ *
+ * @return
+ *  - ESP_OK    : On successfully initiating closure
+ *  - ESP_FAIL  : Failure to queue work
+ *  - ESP_ERR_NOT_FOUND   : Socket fd not found
+ *  - ESP_ERR_INVALID_ARG : Null arguments
+ */
+esp_err_t httpd_sess_trigger_close_(httpd_handle_t handle, struct sock_db *session);
+
+/** End of WebSocket related functions
+ * @}
+ */
+
+#if CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT == -1
+#define ESP_HTTP_SERVER_EVENT_POST_TIMEOUT portMAX_DELAY
+#else
+#define ESP_HTTP_SERVER_EVENT_POST_TIMEOUT pdMS_TO_TICKS(CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT)
+#endif
+
+/**
+ * @brief Function to dispatch events in default event loop
+ *
+ */
+void esp_http_server_dispatch_event(int32_t event_id, const void* event_data, size_t event_data_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _HTTPD_PRIV_H_ */

--- a/components/esp_http_server/src/httpd_main.c
+++ b/components/esp_http_server/src/httpd_main.c
@@ -1,0 +1,595 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/param.h>
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <assert.h>
+#include <netinet/tcp.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+#include "ctrl_sock.h"
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+#include "freertos/semphr.h"
+#endif
+
+#if defined(CONFIG_LWIP_MAX_SOCKETS)
+#define HTTPD_MAX_SOCKETS CONFIG_LWIP_MAX_SOCKETS
+#else
+/* LwIP component is not included into the build, use a default value */
+#define HTTPD_MAX_SOCKETS 15
+#endif
+
+static const int DEFAULT_KEEP_ALIVE_IDLE = 5;
+static const int DEFAULT_KEEP_ALIVE_INTERVAL= 5;
+static const int DEFAULT_KEEP_ALIVE_COUNT= 3;
+
+typedef struct {
+    fd_set *fdset;
+    struct httpd_data *hd;
+} process_session_context_t;
+
+static const char *TAG = "httpd";
+
+ESP_EVENT_DEFINE_BASE(ESP_HTTP_SERVER_EVENT);
+
+void esp_http_server_dispatch_event(int32_t event_id, const void* event_data, size_t event_data_size)
+{
+    esp_err_t err = esp_event_post(ESP_HTTP_SERVER_EVENT, event_id, event_data, event_data_size, ESP_HTTP_SERVER_EVENT_POST_TIMEOUT);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to post esp_http_server event: %s", esp_err_to_name(err));
+    }
+}
+
+static esp_err_t httpd_accept_conn(struct httpd_data *hd, int listen_fd)
+{
+    /* If no space is available for new session, close the least recently used one */
+    if (hd->config.lru_purge_enable == true) {
+        if (!httpd_is_sess_available(hd)) {
+            /* Queue asynchronous closure of the least recently used session */
+            return httpd_sess_close_lru(hd);
+            /* Returning from this allows the main server thread to process
+             * the queued asynchronous control message for closing LRU session.
+             * Since connection request hasn't been addressed yet using accept()
+             * therefore httpd_accept_conn() will be called again, but this time
+             * with space available for one session
+             */
+        }
+    }
+
+    struct sockaddr_storage addr_from;
+    socklen_t addr_from_len = sizeof(addr_from);
+    int new_fd = accept(listen_fd, (struct sockaddr *)&addr_from, &addr_from_len);
+    if (new_fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in accept (%d)"), errno);
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("newfd = %d"), new_fd);
+
+    struct timeval tv;
+    /* Set recv timeout of this fd as per config */
+    tv.tv_sec = hd->config.recv_wait_timeout;
+    tv.tv_usec = 0;
+    if (setsockopt(new_fd, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv)) < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in setsockopt SO_RCVTIMEO (%d)"), errno);
+        goto exit;
+    }
+
+    /* Set send timeout of this fd as per config */
+    tv.tv_sec = hd->config.send_wait_timeout;
+    tv.tv_usec = 0;
+    if (setsockopt(new_fd, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv)) < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in setsockopt SO_SNDTIMEO (%d)"), errno);
+        goto exit;
+    }
+
+    if (hd->config.keep_alive_enable) {
+        int keep_alive_enable = 1;
+        int keep_alive_idle = hd->config.keep_alive_idle ? hd->config.keep_alive_idle : DEFAULT_KEEP_ALIVE_IDLE;
+        int keep_alive_interval = hd->config.keep_alive_interval ? hd->config.keep_alive_interval : DEFAULT_KEEP_ALIVE_INTERVAL;
+        int keep_alive_count = hd->config.keep_alive_count ? hd->config.keep_alive_count : DEFAULT_KEEP_ALIVE_COUNT;
+        ESP_LOGD(TAG, "Enable TCP keep alive. idle: %d, interval: %d, count: %d", keep_alive_idle, keep_alive_interval, keep_alive_count);
+
+        if (setsockopt(new_fd, SOL_SOCKET, SO_KEEPALIVE, &keep_alive_enable, sizeof(keep_alive_enable)) < 0) {
+            ESP_LOGE(TAG, LOG_FMT("error in setsockopt SO_KEEPALIVE (%d)"), errno);
+            goto exit;
+        }
+#ifndef __APPLE__
+        if (setsockopt(new_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keep_alive_idle, sizeof(keep_alive_idle)) < 0) {
+            ESP_LOGE(TAG, LOG_FMT("error in setsockopt TCP_KEEPIDLE (%d)"), errno);
+            goto exit;
+        }
+        if (setsockopt(new_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keep_alive_interval, sizeof(keep_alive_interval)) < 0) {
+            ESP_LOGE(TAG, LOG_FMT("error in setsockopt TCP_KEEPINTVL (%d)"), errno);
+            goto exit;
+        }
+        if (setsockopt(new_fd, IPPROTO_TCP, TCP_KEEPCNT, &keep_alive_count, sizeof(keep_alive_count)) < 0) {
+            ESP_LOGE(TAG, LOG_FMT("error in setsockopt TCP_KEEPCNT (%d)"), errno);
+            goto exit;
+        }
+#else // __APPLE__
+        if (setsockopt(new_fd, IPPROTO_TCP, TCP_KEEPALIVE, &keep_alive_idle, sizeof(keep_alive_idle)) < 0) {
+            ESP_LOGE(TAG, LOG_FMT("error in setsockopt TCP_KEEPALIVE (%d)"), errno);
+            goto exit;
+        }
+#endif // __APPLE__
+    }
+    if (ESP_OK != httpd_sess_new(hd, new_fd)) {
+        ESP_LOGE(TAG, LOG_FMT("session creation failed"));
+        goto exit;
+    }
+    ESP_LOGD(TAG, LOG_FMT("complete"));
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_ON_CONNECTED, &new_fd, sizeof(int));
+    return ESP_OK;
+exit:
+    close(new_fd);
+    return ESP_FAIL;
+}
+
+struct httpd_ctrl_data {
+    enum httpd_ctrl_msg {
+        HTTPD_CTRL_SHUTDOWN,
+        HTTPD_CTRL_WORK,
+    } hc_msg;
+    httpd_work_fn_t hc_work;
+    void *hc_work_arg;
+};
+
+esp_err_t httpd_queue_work(httpd_handle_t handle, httpd_work_fn_t work, void *arg)
+{
+    if (handle == NULL || work == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    struct httpd_ctrl_data msg = {
+        .hc_msg = HTTPD_CTRL_WORK,
+        .hc_work = work,
+        .hc_work_arg = arg,
+    };
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+    // Semaphore is acquired here and released after work function is executed.
+    if (xSemaphoreTake(hd->ctrl_sock_semaphore, portMAX_DELAY) == pdTRUE) {
+#endif
+        int ret = cs_send_to_ctrl_sock(hd->msg_fd, hd->config.ctrl_port, &msg, sizeof(msg));
+        if (ret < 0) {
+            ESP_LOGW(TAG, LOG_FMT("failed to queue work"));
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+            xSemaphoreGive(hd->ctrl_sock_semaphore);
+#endif
+            return ESP_FAIL;
+        }
+        return ESP_OK;
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+    }
+    ESP_LOGE(TAG, "Unable to acquire semaphore");
+    return ESP_FAIL;
+#endif
+}
+
+esp_err_t httpd_get_client_list(httpd_handle_t handle, size_t *fds, int *client_fds)
+{
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd == NULL || fds == NULL || *fds == 0 || client_fds == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    size_t max_fds = *fds;
+    *fds = 0;
+    for (int i = 0; i < hd->config.max_open_sockets; ++i) {
+        if (hd->hd_sd[i].fd != -1) {
+            if (*fds < max_fds) {
+                client_fds[(*fds)++] = hd->hd_sd[i].fd;
+            } else {
+                return ESP_ERR_INVALID_ARG;
+            }
+        }
+    }
+    return ESP_OK;
+}
+
+void *httpd_get_global_user_ctx(httpd_handle_t handle)
+{
+    return ((struct httpd_data *)handle)->config.global_user_ctx;
+}
+
+void *httpd_get_global_transport_ctx(httpd_handle_t handle)
+{
+    return ((struct httpd_data *)handle)->config.global_transport_ctx;
+}
+
+
+static void httpd_process_ctrl_msg(struct httpd_data *hd)
+{
+    struct httpd_ctrl_data msg;
+    int ret = recv(hd->ctrl_fd, &msg, sizeof(msg), 0);
+    if (ret <= 0) {
+        ESP_LOGW(TAG, LOG_FMT("error in recv (%d)"), errno);
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+        xSemaphoreGive(hd->ctrl_sock_semaphore);
+#endif
+        return;
+    }
+    if (ret != sizeof(msg)) {
+        ESP_LOGW(TAG, LOG_FMT("incomplete msg"));
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+        xSemaphoreGive(hd->ctrl_sock_semaphore);
+#endif
+        return;
+    }
+
+    switch (msg.hc_msg) {
+    case HTTPD_CTRL_WORK:
+        if (msg.hc_work) {
+            ESP_LOGD(TAG, LOG_FMT("work"));
+            (*msg.hc_work)(msg.hc_work_arg);
+        }
+        break;
+    case HTTPD_CTRL_SHUTDOWN:
+        ESP_LOGD(TAG, LOG_FMT("shutdown"));
+        hd->hd_td.status = THREAD_STOPPING;
+        break;
+    default:
+        break;
+    }
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+    xSemaphoreGive(hd->ctrl_sock_semaphore);
+#endif
+}
+
+// Called for each session from httpd_server
+static int httpd_process_session(struct sock_db *session, void *context)
+{
+    if ((!session) || (!context)) {
+        return 0;
+    }
+
+    if (session->fd < 0) {
+        return 1;
+    }
+
+    // session is busy in an async task, do not process here.
+    if (session->for_async_req) {
+        return 1;
+    }
+
+    process_session_context_t *ctx = (process_session_context_t *)context;
+    int fd = session->fd;
+
+    if (FD_ISSET(fd, ctx->fdset) || httpd_sess_pending(ctx->hd, session)) {
+        ESP_LOGD(TAG, LOG_FMT("processing socket %d"), fd);
+        if (httpd_sess_process(ctx->hd, session) != ESP_OK) {
+            httpd_sess_delete(ctx->hd, session); // Delete session
+        }
+    }
+    return 1;
+}
+
+/* Manage in-coming connection or data requests */
+static esp_err_t httpd_server(struct httpd_data *hd)
+{
+    fd_set read_set;
+    FD_ZERO(&read_set);
+    if (hd->config.lru_purge_enable || httpd_is_sess_available(hd)) {
+        /* Only listen for new connections if server has capacity to
+         * handle more (or when LRU purge is enabled, in which case
+         * older connections will be closed) */
+        FD_SET(hd->listen_fd, &read_set);
+    }
+    FD_SET(hd->ctrl_fd, &read_set);
+
+    int tmp_max_fd;
+    httpd_sess_set_descriptors(hd, &read_set, &tmp_max_fd);
+    int maxfd = MAX(hd->listen_fd, tmp_max_fd);
+    tmp_max_fd = maxfd;
+    maxfd = MAX(hd->ctrl_fd, tmp_max_fd);
+
+    ESP_LOGD(TAG, LOG_FMT("doing select maxfd+1 = %d"), maxfd + 1);
+    int active_cnt = select(maxfd + 1, &read_set, NULL, NULL, NULL);
+    if (active_cnt < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in select (%d)"), errno);
+        httpd_sess_delete_invalid(hd);
+        return ESP_OK;
+    }
+
+    /* Case0: Do we have a control message? */
+    if (FD_ISSET(hd->ctrl_fd, &read_set)) {
+        ESP_LOGD(TAG, LOG_FMT("processing ctrl message"));
+        httpd_process_ctrl_msg(hd);
+        if (hd->hd_td.status == THREAD_STOPPING) {
+            ESP_LOGD(TAG, LOG_FMT("stopping thread"));
+            return ESP_FAIL;
+        }
+    }
+
+    /* Case1: Do we have any activity on the current data
+     * sessions? */
+    process_session_context_t context = {
+        .fdset = &read_set,
+        .hd = hd
+    };
+    httpd_sess_enum(hd, httpd_process_session, &context);
+
+    /* Case2: Do we have any incoming connection requests to
+     * process? */
+    if (FD_ISSET(hd->listen_fd, &read_set)) {
+        ESP_LOGD(TAG, LOG_FMT("processing listen socket %d"), hd->listen_fd);
+        if (httpd_accept_conn(hd, hd->listen_fd) != ESP_OK) {
+            ESP_LOGW(TAG, LOG_FMT("error accepting new connection"));
+        }
+    }
+    return ESP_OK;
+}
+
+/* The main HTTPD thread */
+static void httpd_thread(void *arg)
+{
+    int ret;
+    struct httpd_data *hd = (struct httpd_data *) arg;
+    hd->hd_td.status = THREAD_RUNNING;
+
+    ESP_LOGD(TAG, LOG_FMT("web server started"));
+    while (1) {
+        ret = httpd_server(hd);
+        if (ret != ESP_OK) {
+            break;
+        }
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("web server exiting"));
+    close(hd->msg_fd);
+    cs_free_ctrl_sock(hd->ctrl_fd);
+    httpd_sess_close_all(hd);
+    close(hd->listen_fd);
+    hd->hd_td.status = THREAD_STOPPED;
+    httpd_os_thread_delete();
+}
+
+static esp_err_t httpd_server_init(struct httpd_data *hd)
+{
+#if CONFIG_LWIP_IPV6
+    int fd = socket(PF_INET6, SOCK_STREAM, 0);
+#else
+    int fd = socket(PF_INET, SOCK_STREAM, 0);
+#endif
+    if (fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in socket (%d)"), errno);
+        return ESP_FAIL;
+    }
+#if CONFIG_LWIP_IPV6
+    struct in6_addr inaddr_any = IN6ADDR_ANY_INIT;
+    struct sockaddr_in6 serv_addr = {
+        .sin6_family  = PF_INET6,
+        .sin6_addr    = inaddr_any,
+        .sin6_port    = htons(hd->config.server_port)
+    };
+#else
+    struct sockaddr_in serv_addr = {
+        .sin_family   = PF_INET,
+        .sin_addr     = {
+            .s_addr = htonl(INADDR_ANY)
+        },
+        .sin_port     = htons(hd->config.server_port)
+    };
+#endif
+    /* Enable SO_REUSEADDR to allow binding to the same
+     * address and port when restarting the server */
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+        /* This will fail if CONFIG_LWIP_SO_REUSE is not enabled. But
+         * it does not affect the normal working of the HTTP Server */
+        ESP_LOGW(TAG, LOG_FMT("error in setsockopt SO_REUSEADDR (%d)"), errno);
+    }
+
+    int ret = bind(fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+    if (ret < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in bind (%d)"), errno);
+        close(fd);
+        return ESP_FAIL;
+    }
+
+    ret = listen(fd, hd->config.backlog_conn);
+    if (ret < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in listen (%d)"), errno);
+        close(fd);
+        return ESP_FAIL;
+    }
+
+    int ctrl_fd = cs_create_ctrl_sock(hd->config.ctrl_port);
+    if (ctrl_fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in creating ctrl socket (%d)"), errno);
+        close(fd);
+        return ESP_FAIL;
+    }
+
+    int msg_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (msg_fd < 0) {
+        ESP_LOGE(TAG, LOG_FMT("error in creating msg socket (%d)"), errno);
+        close(fd);
+        close(ctrl_fd);
+        return ESP_FAIL;
+    }
+
+    hd->listen_fd = fd;
+    hd->ctrl_fd = ctrl_fd;
+    hd->msg_fd  = msg_fd;
+    return ESP_OK;
+}
+
+static struct httpd_data *httpd_create(const httpd_config_t *config)
+{
+    /* Allocate memory for httpd instance data */
+    struct httpd_data *hd = calloc(1, sizeof(struct httpd_data));
+    if (!hd) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP server instance"));
+        return NULL;
+    }
+    hd->hd_calls = calloc(config->max_uri_handlers, sizeof(httpd_uri_t *));
+    if (!hd->hd_calls) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP URI handlers"));
+        free(hd);
+        return NULL;
+    }
+    hd->hd_sd = calloc(config->max_open_sockets, sizeof(struct sock_db));
+    if (!hd->hd_sd) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP session data"));
+        free(hd->hd_calls);
+        free(hd);
+        return NULL;
+    }
+    struct httpd_req_aux *ra = &hd->hd_req_aux;
+    ra->resp_hdrs = calloc(config->max_resp_headers, sizeof(struct resp_hdr));
+    if (!ra->resp_hdrs) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP response headers"));
+        free(hd->hd_sd);
+        free(hd->hd_calls);
+        free(hd);
+        return NULL;
+    }
+    hd->err_handler_fns = calloc(HTTPD_ERR_CODE_MAX, sizeof(httpd_err_handler_func_t));
+    if (!hd->err_handler_fns) {
+        ESP_LOGE(TAG, LOG_FMT("Failed to allocate memory for HTTP error handlers"));
+        free(ra->resp_hdrs);
+        free(hd->hd_sd);
+        free(hd->hd_calls);
+        free(hd);
+        return NULL;
+    }
+    /* Save the configuration for this instance */
+    hd->config = *config;
+    return hd;
+}
+
+static void httpd_delete(struct httpd_data *hd)
+{
+    struct httpd_req_aux *ra = &hd->hd_req_aux;
+    /* Free memory of httpd instance data */
+    free(hd->err_handler_fns);
+    free(ra->resp_hdrs);
+    free(hd->hd_sd);
+
+    /* Free registered URI handlers */
+    httpd_unregister_all_uri_handlers(hd);
+    free(hd->hd_calls);
+    free(hd);
+}
+
+esp_err_t httpd_start(httpd_handle_t *handle, const httpd_config_t *config)
+{
+    if (handle == NULL || config == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Sanity check about whether LWIP is configured for providing the
+     * maximum number of open sockets sufficient for the server. Though,
+     * this check doesn't guarantee that many sockets will actually be
+     * available at runtime as other processes may use up some sockets.
+     * Note that server also uses 3 sockets for its internal use :
+     *     1) listening for new TCP connections
+     *     2) for sending control messages over UDP
+     *     3) for receiving control messages over UDP
+     * So the total number of required sockets is max_open_sockets + 3
+     */
+    if (HTTPD_MAX_SOCKETS < config->max_open_sockets + 3) {
+        ESP_LOGE(TAG, "Config option max_open_sockets is too large (max allowed %d, 3 sockets used by HTTP server internally)\n\t"
+                 "Either decrease this or configure LWIP_MAX_SOCKETS to a larger value",
+                 HTTPD_MAX_SOCKETS - 3);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = httpd_create(config);
+    if (hd == NULL) {
+        /* Failed to allocate memory */
+        return ESP_ERR_HTTPD_ALLOC_MEM;
+    }
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+    /* Using a Counting Semaphore with count equals CONFIG_LWIP_UDP_RECVMBOX_SIZE
+     * as the number of UDP messages which can be stored is equal to UDP mailbox size.
+     * Using this, we can make sure that the work function is always received by the ctrl socket.
+     */
+    hd->ctrl_sock_semaphore = xSemaphoreCreateCounting(CONFIG_LWIP_UDP_RECVMBOX_SIZE, CONFIG_LWIP_UDP_RECVMBOX_SIZE);
+    if (hd->ctrl_sock_semaphore == NULL) {
+        ESP_LOGE(TAG, "Failed to create Semaphore");
+        httpd_delete(hd);
+        return ESP_ERR_HTTPD_ALLOC_MEM;
+    }
+#endif
+
+    if (httpd_server_init(hd) != ESP_OK) {
+        httpd_delete(hd);
+        return ESP_FAIL;
+    }
+
+    httpd_sess_init(hd);
+    if (httpd_os_thread_create(&hd->hd_td.handle, "httpd",
+                               hd->config.stack_size,
+                               hd->config.task_priority,
+                               httpd_thread, hd,
+                               hd->config.core_id,
+                               hd->config.task_caps) != ESP_OK) {
+        /* Failed to launch task */
+        httpd_delete(hd);
+        return ESP_ERR_HTTPD_TASK;
+    }
+
+    *handle = (httpd_handle_t)hd;
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_START, NULL, 0);
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_stop(httpd_handle_t handle)
+{
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_ctrl_data msg;
+    memset(&msg, 0, sizeof(msg));
+    msg.hc_msg = HTTPD_CTRL_SHUTDOWN;
+    int ret = 0;
+    if ((ret = cs_send_to_ctrl_sock(hd->msg_fd, hd->config.ctrl_port, &msg, sizeof(msg))) < 0) {
+        ESP_LOGE(TAG, "Failed to send shutdown signal err=%d", ret);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("sent control msg to stop server"));
+    while (hd->hd_td.status != THREAD_STOPPED) {
+        httpd_os_thread_sleep(100);
+    }
+
+    /* Release global user context, if not NULL */
+    if (hd->config.global_user_ctx) {
+        if (hd->config.global_user_ctx_free_fn) {
+            hd->config.global_user_ctx_free_fn(hd->config.global_user_ctx);
+        } else {
+            free(hd->config.global_user_ctx);
+        }
+        hd->config.global_user_ctx = NULL;
+    }
+
+    /* Release global transport context, if not NULL */
+    if (hd->config.global_transport_ctx) {
+        if (hd->config.global_transport_ctx_free_fn) {
+            hd->config.global_transport_ctx_free_fn(hd->config.global_transport_ctx);
+        } else {
+            free(hd->config.global_transport_ctx);
+        }
+        hd->config.global_transport_ctx = NULL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("server stopped"));
+#if CONFIG_HTTPD_QUEUE_WORK_BLOCKING
+    vSemaphoreDelete(hd->ctrl_sock_semaphore);
+#endif
+    httpd_delete(hd);
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_STOP, NULL, 0);
+    return ESP_OK;
+}

--- a/components/esp_http_server/src/httpd_parse.c
+++ b/components/esp_http_server/src/httpd_parse.c
@@ -1,0 +1,1233 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <http_parser.h>
+#include <inttypes.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+#include "osal.h"
+
+static const char *TAG = "httpd_parse";
+
+typedef struct {
+    /* Parser settings for http_parser_execute() */
+    http_parser_settings settings;
+
+    /* Request being parsed */
+    struct httpd_req *req;
+
+    /* Status of the parser describes the part of the
+     * HTTP request packet being processed at any moment.
+     */
+    enum {
+        PARSING_IDLE = 0,
+        PARSING_URL,
+        PARSING_HDR_FIELD,
+        PARSING_HDR_VALUE,
+        PARSING_BODY,
+        PARSING_COMPLETE,
+        PARSING_FAILED
+    } status;
+
+    /* Response error code in case of PARSING_FAILED */
+    httpd_err_code_t error;
+
+    /* For storing last callback parameters */
+    struct {
+        const char *at;
+        size_t      length;
+    } last;
+
+    /* State variables */
+    bool   paused;          /*!< Parser is paused */
+    size_t pre_parsed;      /*!< Length of data to be skipped while parsing */
+    size_t raw_datalen;     /*!< Full length of the raw data in scratch buffer */
+} parser_data_t;
+
+static esp_err_t verify_url (http_parser *parser)
+{
+    parser_data_t *parser_data  = (parser_data_t *) parser->data;
+    struct httpd_req *r         = parser_data->req;
+    struct httpd_req_aux *ra    = r->aux;
+    struct http_parser_url *res = &ra->url_parse_res;
+
+    /* Get previous values of the parser callback arguments */
+    const char *at = parser_data->last.at;
+    size_t  length = parser_data->last.length;
+
+    r->method = parser->method;
+    if (r->method < 0) {
+        ESP_LOGW(TAG, LOG_FMT("HTTP method not supported (%d)"), r->method);
+        parser_data->error = HTTPD_501_METHOD_NOT_IMPLEMENTED;
+        return ESP_FAIL;
+    }
+
+    if (sizeof(r->uri) < (length + 1)) {
+        ESP_LOGW(TAG, LOG_FMT("URI length (%"NEWLIB_NANO_COMPAT_FORMAT") greater than supported (%"NEWLIB_NANO_COMPAT_FORMAT")"),
+                 NEWLIB_NANO_COMPAT_CAST(length), NEWLIB_NANO_COMPAT_CAST(sizeof(r->uri)));
+        parser_data->error = HTTPD_414_URI_TOO_LONG;
+        return ESP_FAIL;
+    }
+
+    /* Copy URI and append terminating null character. Note URI string pointed
+     * by 'at' is not NULL terminated, therefore use length provided by
+     * parser while copying the URI to buffer */
+    memcpy((char *)r->uri, at, length);
+    ((char *)r->uri)[length] = '\0';
+    ESP_LOGD(TAG, LOG_FMT("received URI = %s"), r->uri);
+
+    /* Make sure version is HTTP/1.1 or HTTP/1.0 (legacy compliance purpose) */
+    if (!((parser->http_major == 1) && ((parser->http_minor == 0) || (parser->http_minor == 1)))) {
+        ESP_LOGW(TAG, LOG_FMT("unsupported HTTP version = %d.%d"),
+                 parser->http_major, parser->http_minor);
+        parser_data->error = HTTPD_505_VERSION_NOT_SUPPORTED;
+        return ESP_FAIL;
+    }
+
+    /* Parse URL and keep result for later */
+    http_parser_url_init(res);
+    if (http_parser_parse_url(r->uri, length,
+                              r->method == HTTP_CONNECT, res)) {
+        ESP_LOGW(TAG, LOG_FMT("http_parser_parse_url failed with errno = %d"),
+                              parser->http_errno);
+        parser_data->error = HTTPD_400_BAD_REQUEST;
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+/* http_parser callback on finding url in HTTP request
+ * Will be invoked AT LEAST once every packet
+ */
+static esp_err_t cb_url(http_parser *parser,
+                        const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    httpd_req_t          *req   = parser_data->req;
+    struct httpd_req_aux *raux  = req->aux;
+
+    if (parser_data->status == PARSING_IDLE) {
+        ESP_LOGD(TAG, LOG_FMT("message begin"));
+
+        /* Store current values of the parser callback arguments */
+        parser_data->last.at     = at;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_URL;
+    } else if (parser_data->status != PARSING_URL) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("processing url = %.*s"), (int)length, at);
+
+    /* Update length of URL string */
+    if ((parser_data->last.length += length) > raux->max_uri_len) {
+        ESP_LOGW(TAG, LOG_FMT("URI length (%"NEWLIB_NANO_COMPAT_FORMAT") greater than supported (%d)"),
+                 NEWLIB_NANO_COMPAT_CAST(parser_data->last.length), raux->max_uri_len);
+        parser_data->error = HTTPD_414_URI_TOO_LONG;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t pause_parsing(http_parser *parser, const char* at)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    struct httpd_req *r        = parser_data->req;
+    struct httpd_req_aux *ra   = r->aux;
+
+    /* The length of data that was not parsed due to interruption
+     * and hence needs to be read again later for parsing */
+    ssize_t unparsed = parser_data->raw_datalen - (at - ra->scratch);
+    if (unparsed < 0) {
+        ESP_LOGE(TAG, LOG_FMT("parsing beyond valid data = %d"), (int)(-unparsed));
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Push back the un-parsed data into pending buffer for
+     * receiving again with httpd_recv_with_opt() later when
+     * read_block() executes */
+    if (unparsed && (unparsed != httpd_unrecv(r, at, unparsed))) {
+        ESP_LOGE(TAG, LOG_FMT("data too large for un-recv = %d"), (int)unparsed);
+        return ESP_FAIL;
+    }
+
+    /* Signal http_parser to pause execution and save the maximum
+     * possible length, of the yet un-parsed data, that may get
+     * parsed before http_parser_execute() returns. This pre_parsed
+     * length will be updated then to reflect the actual length
+     * that got parsed, and must be skipped when parsing resumes */
+    parser_data->pre_parsed = unparsed;
+    http_parser_pause(parser, 1);
+    parser_data->paused = true;
+    ESP_LOGD(TAG, LOG_FMT("paused"));
+    return ESP_OK;
+}
+
+static size_t continue_parsing(http_parser *parser, size_t length)
+{
+    parser_data_t *data = (parser_data_t *) parser->data;
+
+    /* Part of the received data may have been parsed earlier
+     * so we must skip that before parsing resumes */
+    length = MIN(length, data->pre_parsed);
+    data->pre_parsed -= length;
+    ESP_LOGD(TAG, LOG_FMT("skip pre-parsed data of size = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST(length));
+
+    http_parser_pause(parser, 0);
+    data->paused = false;
+    ESP_LOGD(TAG, LOG_FMT("un-paused"));
+    return length;
+}
+
+/* http_parser callback on header field in HTTP request
+ * May be invoked AT LEAST once every header field
+ */
+static esp_err_t cb_header_field(http_parser *parser, const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    struct httpd_req *r        = parser_data->req;
+    struct httpd_req_aux *ra   = r->aux;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_URL) {
+        if (verify_url(parser) != ESP_OK) {
+            /* verify_url would already have set the
+             * error field of parser data, so only setting
+             * status to failed */
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        ESP_LOGD(TAG, LOG_FMT("headers begin"));
+        /* Last at is set to start of scratch where headers
+         * will be received next */
+        parser_data->last.at     = ra->scratch;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_HDR_FIELD;
+        ra->scratch_size_limit   = ra->max_req_hdr_len;
+
+        /* Stop parsing for now and give control to process */
+        if (pause_parsing(parser, at) != ESP_OK) {
+            parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+    } else if (parser_data->status == PARSING_HDR_VALUE) {
+        /* Overwrite terminator (CRLFs) following last header
+         * (key: value) pair with null characters */
+        char *term_start = (char *)parser_data->last.at + parser_data->last.length;
+        memset(term_start, '\0', at - term_start);
+
+        /* Store current values of the parser callback arguments */
+        parser_data->last.at     = at;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_HDR_FIELD;
+        ra->scratch_size_limit   = ra->max_req_hdr_len;
+
+        /* Increment header count */
+        ra->req_hdrs_count++;
+    } else if (parser_data->status != PARSING_HDR_FIELD) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("processing field = %.*s"), (int)length, at);
+
+    /* Update length of header string */
+    parser_data->last.length += length;
+    return ESP_OK;
+}
+
+/* http_parser callback on header value in HTTP request.
+ * May be invoked AT LEAST once every header value
+ */
+static esp_err_t cb_header_value(http_parser *parser, const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_HDR_FIELD) {
+        /* Store current values of the parser callback arguments */
+        parser_data->last.at     = at;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_HDR_VALUE;
+
+        if (length == 0) {
+            /* As per behavior of http_parser, when length > 0,
+             * `at` points to the start of CRLF. But, in the
+             * case when header value is empty (zero length),
+             * then `at` points to the position right after
+             * the CRLF. Since for our purpose we need `last.at`
+             * to point to exactly where the CRLF starts, it
+             * needs to be adjusted by the right offset */
+            char *at_adj = (char *)parser_data->last.at;
+            /* Find the end of header field string */
+            while (*(--at_adj) != ':');
+            /* Now skip leading spaces' */
+            while (*(++at_adj) == ' ');
+            /* Now we are at the right position */
+            parser_data->last.at = at_adj;
+        }
+    } else if (parser_data->status != PARSING_HDR_VALUE) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("processing value = %.*s"), (int)length, at);
+
+    /* Update length of header string */
+    parser_data->last.length += length;
+    return ESP_OK;
+}
+
+/* http_parser callback on completing headers in HTTP request.
+ * Will be invoked ONLY once every packet
+ */
+static esp_err_t cb_headers_complete(http_parser *parser)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+    struct httpd_req *r        = parser_data->req;
+    struct httpd_req_aux *ra   = r->aux;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_URL) {
+        ESP_LOGD(TAG, LOG_FMT("no headers"));
+        if (verify_url(parser) != ESP_OK) {
+            /* verify_url would already have set the
+             * error field of parser data, so only setting
+             * status to failed */
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+    } else if (parser_data->status == PARSING_HDR_VALUE) {
+        /* Locate end of last header */
+        char *at = (char *)parser_data->last.at + parser_data->last.length;
+
+        /* Check if there is data left to parse. This value should
+         * at least be equal to the number of line terminators, i.e. 2 */
+        ssize_t remaining_length = parser_data->raw_datalen - (at - ra->scratch);
+        if (remaining_length < 2) {
+            ESP_LOGE(TAG, LOG_FMT("invalid length of data remaining to be parsed"));
+            parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        /* Locate end of headers section by skipping the remaining
+         * two line terminators. No assumption is made here about the
+         * termination sequence used apart from the necessity that it
+         * must end with an LF, because:
+         *      1) some clients may send non standard LFs instead of
+         *         CRLFs for indicating termination.
+         *      2) it is the responsibility of http_parser to check
+         *         that the termination is either CRLF or LF and
+         *         not any other sequence */
+        unsigned short remaining_terminators = 2;
+        while (remaining_length-- && remaining_terminators) {
+            if (*at == '\n') {
+                remaining_terminators--;
+            }
+            /* Overwrite termination characters with null */
+            *(at++) = '\0';
+        }
+        if (remaining_terminators) {
+            ESP_LOGE(TAG, LOG_FMT("incomplete termination of headers"));
+            parser_data->error = HTTPD_400_BAD_REQUEST;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        /* Place the parser ptr right after the end of headers section */
+        parser_data->last.at = at;
+
+        /* Increment header count */
+        ra->req_hdrs_count++;
+    } else {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    /* In absence of body/chunked encoding, http_parser sets content_len to -1 */
+    r->content_len = ((int)parser->content_length != -1 ?
+                      parser->content_length : 0);
+
+    ESP_LOGD(TAG, LOG_FMT("bytes read     = %" PRId32 ""),  parser->nread);
+    ESP_LOGD(TAG, LOG_FMT("content length = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST(r->content_len));
+
+    /* Handle upgrade requests - only WebSocket is supported for now */
+    if (parser->upgrade) {
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+        ESP_LOGD(TAG, LOG_FMT("Got an upgrade request"));
+
+        /* If there's no "Upgrade" header field, then it's not WebSocket. */
+        char ws_upgrade_hdr_val[] = "websocket";
+        if (httpd_req_get_hdr_value_str(r, "Upgrade", ws_upgrade_hdr_val, sizeof(ws_upgrade_hdr_val)) != ESP_OK) {
+            ESP_LOGW(TAG, LOG_FMT("Upgrade header does not match the length of \"websocket\""));
+            parser_data->error = HTTPD_400_BAD_REQUEST;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        /* If "Upgrade" field's key is not "websocket", then we should also forget about it. */
+        if (strcasecmp("websocket", ws_upgrade_hdr_val) != 0) {
+            ESP_LOGW(TAG, LOG_FMT("Upgrade header found but it's %s"), ws_upgrade_hdr_val);
+            parser_data->error = HTTPD_400_BAD_REQUEST;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+
+        /* Now set handshake flag to true */
+        ra->ws_handshake_detect = true;
+#else
+        ESP_LOGD(TAG, LOG_FMT("WS functions has been disabled, Upgrade request is not supported."));
+        parser_data->error = HTTPD_400_BAD_REQUEST;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+#endif
+    }
+
+    /* MEATLOAF PATCH (chunked request bodies): for Transfer-Encoding: chunked,
+     * http_parser de-chunks the body itself and consumes the first chunk-size
+     * line before cb_on_body gets a chance to pause -- so the data pushed back
+     * into the pending buffer starts mid-chunk and the URI handler can never
+     * recover the framing (the consumed chunk length lives only in the parser
+     * state, which is gone by handler time). Pause HERE, right at the end of
+     * the headers, so the entire raw (still-chunked) body is preserved in the
+     * pending buffer for the handler to read and de-chunk itself (see
+     * lib/www/webdav Request::readBodyChunked). content_len stays 0, matching
+     * the handler-side "chunked == no Content-Length" detection. */
+    if (parser->flags & F_CHUNKED) {
+        if (pause_parsing(parser, parser_data->last.at) != ESP_OK) {
+            parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+        parser_data->last.at     = 0;
+        parser_data->last.length = 0;
+        parser_data->status      = PARSING_COMPLETE;
+        ESP_LOGD(TAG, LOG_FMT("chunked body: deferred to handler unparsed"));
+        return ESP_OK;
+    }
+
+    parser_data->status = PARSING_BODY;
+    ra->remaining_len = r->content_len;
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_ON_HEADER, &(ra->sd->fd), sizeof(int));
+    return ESP_OK;
+}
+
+/* Last http_parser callback if body present in HTTP request.
+ * Will be invoked ONLY once every packet
+ */
+static esp_err_t cb_on_body(http_parser *parser, const char *at, size_t length)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Check previous status */
+    if (parser_data->status != PARSING_BODY) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    /* Pause parsing so that if part of another packet
+     * is in queue then it doesn't get parsed, which
+     * may reset the parser state and cause current
+     * request packet to be lost */
+    if (pause_parsing(parser, at) != ESP_OK) {
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    parser_data->last.at     = 0;
+    parser_data->last.length = 0;
+    parser_data->status      = PARSING_COMPLETE;
+    ESP_LOGD(TAG, LOG_FMT("body begins"));
+    return ESP_OK;
+}
+
+/* Last http_parser callback if body absent in HTTP request.
+ * Will be invoked ONLY once every packet
+ */
+static esp_err_t cb_no_body(http_parser *parser)
+{
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Check previous status */
+    if (parser_data->status == PARSING_URL) {
+        ESP_LOGD(TAG, LOG_FMT("no headers"));
+        if (verify_url(parser) != ESP_OK) {
+            /* verify_url would already have set the
+             * error field of parser data, so only setting
+             * status to failed */
+            parser_data->status = PARSING_FAILED;
+            return ESP_FAIL;
+        }
+    } else if (parser_data->status != PARSING_BODY) {
+        ESP_LOGE(TAG, LOG_FMT("unexpected state transition"));
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    /* Pause parsing so that if part of another packet
+     * is in queue then it doesn't get parsed, which
+     * may reset the parser state and cause current
+     * request packet to be lost */
+    if (pause_parsing(parser, parser_data->last.at) != ESP_OK) {
+        parser_data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+        parser_data->status = PARSING_FAILED;
+        return ESP_FAIL;
+    }
+
+    parser_data->last.at     = 0;
+    parser_data->last.length = 0;
+    parser_data->status      = PARSING_COMPLETE;
+    ESP_LOGD(TAG, LOG_FMT("message complete"));
+    return ESP_OK;
+}
+
+static int read_block(httpd_req_t *req, http_parser *parser, size_t offset, size_t length)
+{
+    struct httpd_req_aux *raux  = req->aux;
+    parser_data_t *parser_data = (parser_data_t *) parser->data;
+
+    /* Limits the read to scratch buffer size */
+    ssize_t buf_len = MIN(length, (raux->scratch_size_limit - offset));
+    if (buf_len <= 0) {
+        return 0;
+    }
+    /* Calculate the offset of the current position from the start of the buffer,
+     * as after reallocating the buffer, the base address of the buffer may change.
+     */
+    size_t at_offset = parser_data->last.at - raux->scratch;
+    /* Allocate the buffer according to offset and buf_len. Offset is
+       from where the reading will start and buf_len is till what length
+       the buffer will be read.
+    */
+    raux->scratch = (char*) realloc(raux->scratch, offset + buf_len);
+    if (raux->scratch == NULL) {
+        ESP_LOGE(TAG, "Unable to allocate the scratch buffer");
+        return 0;
+    }
+    parser_data->last.at = raux->scratch + at_offset;
+    raux->scratch_cur_size = offset + buf_len;
+    ESP_LOGD(TAG, "scratch buf qsize = %d", raux->scratch_cur_size);
+    /* Receive data into buffer. If data is pending (from unrecv) then return
+     * immediately after receiving pending data, as pending data may just complete
+     * this request packet. */
+    int nbytes = httpd_recv_with_opt(req, raux->scratch + offset, buf_len, true);
+    if (nbytes < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in httpd_recv"));
+        /* If timeout occurred allow the
+         * situation to be handled */
+        if (nbytes == HTTPD_SOCK_ERR_TIMEOUT) {
+            /* Invoke error handler which may return ESP_OK
+             * to signal for retrying call to recv(), else it may
+             * return ESP_FAIL to signal for closure of socket */
+            return (httpd_req_handle_err(req, HTTPD_408_REQ_TIMEOUT) == ESP_OK) ?
+                    HTTPD_SOCK_ERR_TIMEOUT : HTTPD_SOCK_ERR_FAIL;
+        }
+        /* Some socket error occurred. Return failure
+         * to force closure of underlying socket.
+         * Error message is not sent as socket may not
+         * be valid anymore */
+        return HTTPD_SOCK_ERR_FAIL;
+    } else if (nbytes == 0) {
+        ESP_LOGD(TAG, LOG_FMT("connection closed"));
+        /* Connection closed by client so no
+         * need to send error response */
+        return HTTPD_SOCK_ERR_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("received HTTP request block size = %d"), nbytes);
+    return nbytes;
+}
+
+static int parse_block(http_parser *parser, size_t offset, size_t length)
+{
+    parser_data_t        *data  = (parser_data_t *)(parser->data);
+    httpd_req_t          *req   = data->req;
+    struct httpd_req_aux *raux  = req->aux;
+    size_t nparsed = 0;
+
+    if (!length) {
+        /* Parsing is still happening but nothing to
+         * parse means no more space left on buffer,
+         * therefore it can be inferred that the
+         * request URI/header must be too long */
+        switch (data->status) {
+            case PARSING_URL:
+                ESP_LOGW(TAG, LOG_FMT("request URI too long"));
+                data->error = HTTPD_414_URI_TOO_LONG;
+                break;
+            case PARSING_HDR_FIELD:
+            case PARSING_HDR_VALUE:
+                ESP_LOGW(TAG, LOG_FMT("request header too long"));
+                data->error = HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE;
+                break;
+            default:
+                ESP_LOGE(TAG, LOG_FMT("unexpected state"));
+                data->error = HTTPD_500_INTERNAL_SERVER_ERROR;
+                break;
+        }
+        data->status = PARSING_FAILED;
+        return -1;
+    }
+
+    /* Un-pause the parsing if paused */
+    if (data->paused) {
+        nparsed = continue_parsing(parser, length);
+        length -= nparsed;
+        offset += nparsed;
+        if (!length) {
+            return nparsed;
+        }
+    }
+
+    /* Execute http_parser */
+    nparsed = http_parser_execute(parser, &data->settings,
+                                  raux->scratch + offset, length);
+
+    /* Check state */
+    if (data->status == PARSING_FAILED) {
+        /* It is expected that the error field of
+         * parser data should have been set by now */
+        ESP_LOGW(TAG, LOG_FMT("parsing failed"));
+        return -1;
+    } else if (data->paused) {
+        /* Update the value of pre_parsed which was set when
+         * pause_parsing() was called. (length - nparsed) is
+         * the length of the data that will need to be parsed
+         * again later and hence must be deducted from the
+         * pre_parsed length */
+        data->pre_parsed -= (length - nparsed);
+        return 0;
+    } else if (nparsed != length) {
+        /* http_parser error */
+        data->error  = HTTPD_400_BAD_REQUEST;
+        data->status = PARSING_FAILED;
+        ESP_LOGW(TAG, LOG_FMT("incomplete (%"NEWLIB_NANO_COMPAT_FORMAT"/%"NEWLIB_NANO_COMPAT_FORMAT") with parser error = %d"),
+                 NEWLIB_NANO_COMPAT_CAST(nparsed), NEWLIB_NANO_COMPAT_CAST(length), parser->http_errno);
+        return -1;
+    }
+
+    /* Return with the total length of the request packet
+     * that has been parsed till now */
+    ESP_LOGD(TAG, LOG_FMT("parsed block size = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST((offset + nparsed)));
+    return offset + nparsed;
+}
+
+static void parse_init(httpd_req_t *r, http_parser *parser, parser_data_t *data)
+{
+    /* Initialize parser data */
+    memset(data, 0, sizeof(parser_data_t));
+    data->req = r;
+
+    /* Initialize parser */
+    http_parser_init(parser, HTTP_REQUEST);
+    parser->data = (void *)data;
+
+    /* Initialize parser settings */
+    http_parser_settings_init(&data->settings);
+
+    /* Set parser callbacks */
+    data->settings.on_url              = cb_url;
+    data->settings.on_header_field     = cb_header_field;
+    data->settings.on_header_value     = cb_header_value;
+    data->settings.on_headers_complete = cb_headers_complete;
+    data->settings.on_body             = cb_on_body;
+    data->settings.on_message_complete = cb_no_body;
+}
+
+/* Function that receives TCP data and runs parser on it
+ */
+static esp_err_t httpd_parse_req(struct httpd_data *hd)
+{
+    httpd_req_t *r = &hd->hd_req;
+    int blk_len,  offset;
+    http_parser   parser = {};
+    parser_data_t parser_data = {};
+
+    /* Initialize parser */
+    parse_init(r, &parser, &parser_data);
+
+    /* Set offset to start of scratch buffer */
+    offset = 0;
+    do {
+        /* Read block into scratch buffer */
+        if ((blk_len = read_block(r, &parser, offset, PARSER_BLOCK_SIZE)) < 0) {
+            if (blk_len == HTTPD_SOCK_ERR_TIMEOUT) {
+                /* Retry read in case of non-fatal timeout error.
+                 * read_block() ensures that the timeout error is
+                 * handled properly so that this doesn't get stuck
+                 * in an infinite loop */
+                continue;
+            }
+            /* If not HTTPD_SOCK_ERR_TIMEOUT, returned error must
+             * be HTTPD_SOCK_ERR_FAIL which means we need to return
+             * failure and thereby close the underlying socket */
+            return ESP_FAIL;
+        }
+
+        /* This is used by the callbacks to track
+         * data usage of the buffer */
+        parser_data.raw_datalen = blk_len + offset;
+
+        /* Parse data block from buffer */
+        if ((offset = parse_block(&parser, offset, blk_len)) < 0) {
+            /* HTTP error occurred.
+             * Send error code as response status and
+             * invoke error handler */
+            return httpd_req_handle_err(r, parser_data.error);
+        }
+    } while (parser_data.status != PARSING_COMPLETE);
+
+    ESP_LOGD(TAG, LOG_FMT("parsing complete"));
+    return httpd_uri(hd);
+}
+
+static void init_req(httpd_req_t *r, httpd_config_t *config)
+{
+    r->handle = 0;
+    r->method = 0;
+    memset((char*)r->uri, 0, sizeof(r->uri));
+    r->content_len = 0;
+    r->aux = 0;
+    r->user_ctx = 0;
+    r->sess_ctx = 0;
+    r->free_ctx = 0;
+    r->ignore_sess_ctx_changes = 0;
+}
+
+static void init_req_aux(struct httpd_req_aux *ra, httpd_config_t *config)
+{
+    ra->sd = 0;
+    ra->remaining_len = 0;
+    ra->status = 0;
+    ra->content_type = 0;
+    ra->first_chunk_sent = 0;
+    ra->req_hdrs_count = 0;
+    ra->resp_hdrs_count = 0;
+    ra->scratch = NULL;
+    ra->scratch_cur_size = 0;
+    ra->max_req_hdr_len = (config->max_req_hdr_len > 0) ? config->max_req_hdr_len : CONFIG_HTTPD_MAX_REQ_HDR_LEN;
+    ra->max_uri_len = (config->max_uri_len > 0) ? config->max_uri_len : CONFIG_HTTPD_MAX_URI_LEN;
+    ra->scratch_size_limit = ra->max_uri_len;
+#if CONFIG_HTTPD_WS_SUPPORT
+    ra->ws_handshake_detect = false;
+#endif
+    memset(ra->resp_hdrs, 0, config->max_resp_headers * sizeof(struct resp_hdr));
+}
+
+static void httpd_req_cleanup(httpd_req_t *r)
+{
+    struct httpd_req_aux *ra = r->aux;
+
+    /* Check if the context has changed and needs to be cleared */
+    if ((r->ignore_sess_ctx_changes == false) && (ra->sd->ctx != r->sess_ctx)) {
+        httpd_sess_free_ctx(&ra->sd->ctx, ra->sd->free_ctx);
+    }
+
+#if CONFIG_HTTPD_WS_SUPPORT
+    /* Close the socket when a WebSocket Close request is received */
+    if (ra->sd->ws_close) {
+        ESP_LOGD(TAG, LOG_FMT("Try closing WS connection at FD: %d"), ra->sd->fd);
+        httpd_sess_trigger_close(r->handle, ra->sd->fd);
+    }
+#endif
+
+    /* Retrieve session info from the request into the socket database. */
+    ra->sd->ctx = r->sess_ctx;
+    ra->sd->free_ctx = r->free_ctx;
+    ra->sd->ignore_sess_ctx_changes = r->ignore_sess_ctx_changes;
+
+    /* Clear out the request and request_aux structures */
+    ra->sd = NULL;
+    free(ra->scratch);
+    ra->scratch = NULL;
+    ra->scratch_size_limit = 0;
+    ra->scratch_cur_size = 0;
+    r->handle = NULL;
+    r->aux = NULL;
+    r->user_ctx = NULL;
+}
+
+/* Function that processes incoming TCP data and
+ * updates the http request data httpd_req_t
+ */
+esp_err_t httpd_req_new(struct httpd_data *hd, struct sock_db *sd)
+{
+    httpd_req_t *r = &hd->hd_req;
+    init_req(r, &hd->config);
+    init_req_aux(&hd->hd_req_aux, &hd->config);
+    r->handle = hd;
+    r->aux = &hd->hd_req_aux;
+
+    /* Associate the request to the socket */
+    struct httpd_req_aux *ra = r->aux;
+    ra->sd = sd;
+
+    /* Set defaults */
+    ra->status = (char *)HTTPD_200;
+    ra->content_type = (char *)HTTPD_TYPE_TEXT;
+    ra->first_chunk_sent = false;
+
+    /* Copy session info to the request */
+    r->sess_ctx = sd->ctx;
+    r->free_ctx = sd->free_ctx;
+    r->ignore_sess_ctx_changes = sd->ignore_sess_ctx_changes;
+
+    esp_err_t ret;
+
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+    /* Copy user_ctx to the request */
+    r->user_ctx = sd->ws_user_ctx;
+    /* Handle WebSocket */
+    ESP_LOGD(TAG, LOG_FMT("New request, has WS? %s, sd->ws_handler valid? %s, sd->ws_close? %s"),
+             sd->ws_handshake_done ? "Yes" : "No",
+             sd->ws_handler != NULL ? "Yes" : "No",
+             sd->ws_close ? "Yes" : "No");
+    if (sd->ws_handshake_done && sd->ws_handler != NULL) {
+        if (sd->ws_close == true) {
+            /* WS was marked as close state, do not deal with this socket */
+            ESP_LOGD(TAG, LOG_FMT("WS was marked close"));
+            return ESP_OK;
+        }
+
+        ret = httpd_ws_get_frame_type(r);
+        ESP_LOGD(TAG, LOG_FMT("New WS request from existing socket, ws_type=%d"), ra->ws_type);
+
+        if (ra->ws_type == HTTPD_WS_TYPE_CLOSE) {
+            /*  Only mark ws_close to true if it's a CLOSE frame */
+            sd->ws_close = true;
+        } else if (ra->ws_type == HTTPD_WS_TYPE_PONG) {
+            /* Pass the PONG frames to the handler as well, as user app might send PINGs */
+            ESP_LOGD(TAG, LOG_FMT("Received PONG frame"));
+        }
+
+        /* Call handler if it's a non-control frame (or if handler requests control frames, as well) */
+        if (ret == ESP_OK &&
+            (ra->ws_type < HTTPD_WS_TYPE_CLOSE || sd->ws_control_frames)) {
+            ret = sd->ws_handler(r);
+        }
+
+        if (ret != ESP_OK) {
+            httpd_req_cleanup(r);
+        }
+        return ret;
+    }
+#endif
+
+    /* Parse request */
+    ret = httpd_parse_req(hd);
+    if (ret != ESP_OK) {
+        httpd_req_cleanup(r);
+    }
+    return ret;
+}
+
+/* Function that resets the http request data
+ */
+esp_err_t httpd_req_delete(struct httpd_data *hd)
+{
+    httpd_req_t *r = &hd->hd_req;
+    struct httpd_req_aux *ra = r->aux;
+
+    /* Finish off reading any pending/leftover data */
+    while (ra->remaining_len) {
+        /* Any length small enough not to overload the stack, but large
+         * enough to finish off the buffers fast */
+        char dummy[CONFIG_HTTPD_PURGE_BUF_LEN];
+        int recv_len = MIN(sizeof(dummy), ra->remaining_len);
+        recv_len = httpd_req_recv(r, dummy, recv_len);
+        if (recv_len <= 0) {
+            httpd_req_cleanup(r);
+            return ESP_FAIL;
+        }
+
+        ESP_LOGD(TAG, LOG_FMT("purging data size : %d bytes"), recv_len);
+
+#ifdef CONFIG_HTTPD_LOG_PURGE_DATA
+        /* Enabling this will log discarded binary HTTP content data at
+         * Debug level. For large content data this may not be desirable
+         * as it will clutter the log */
+        ESP_LOGD(TAG, "================= PURGED DATA =================");
+        ESP_LOG_BUFFER_HEX_LEVEL(TAG, dummy, recv_len, ESP_LOG_DEBUG);
+        ESP_LOGD(TAG, "===============================================");
+#endif
+    }
+
+    httpd_req_cleanup(r);
+    return ESP_OK;
+}
+
+/* Validates the request to prevent users from calling APIs, that are to
+ * be called only inside URI handler, outside the handler context
+ */
+bool httpd_validate_req_ptr(httpd_req_t *r)
+{
+    if (r) {
+        struct httpd_data *hd = (struct httpd_data *) r->handle;
+        if (hd) {
+            /* Check if this function is running in the context of
+             * the correct httpd server thread */
+            if (httpd_os_thread_handle() == hd->hd_td.handle) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/* Helper function to get a URL query tag from a query string of the type param1=val1&param2=val2 */
+esp_err_t httpd_query_key_value(const char *qry_str, const char *key, char *val, size_t val_size)
+{
+    if (qry_str == NULL || key == NULL || val == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const char *qry_ptr = qry_str;
+
+    while (strlen(qry_ptr)) {
+        /* Search for the '=' character. Else, it would mean
+         * that the parameter is invalid */
+        const char *val_ptr = strchr(qry_ptr, '=');
+        if (!val_ptr) {
+            break;
+        }
+        size_t offset = val_ptr - qry_ptr;
+
+        /* If the key, does not match, continue searching.
+         * Compare lengths first as key from url is not
+         * null terminated (has '=' in the end) */
+        if ((offset != strlen(key)) ||
+            (strncasecmp(qry_ptr, key, offset))) {
+            /* Get the name=val string. Multiple name=value pairs
+             * are separated by '&' */
+            qry_ptr = strchr(val_ptr, '&');
+            if (!qry_ptr) {
+                break;
+            }
+            qry_ptr++;
+            continue;
+        }
+
+        /* Locate start of next query */
+        qry_ptr = strchr(++val_ptr, '&');
+        /* Or this could be the last query, in which
+         * case get to the end of query string */
+        if (!qry_ptr) {
+            qry_ptr = val_ptr + strlen(val_ptr);
+        }
+
+        /* Query value length does not include terminating null */
+        size_t val_len = qry_ptr - val_ptr;
+
+        /* Copy value to the caller's buffer. */
+        size_t copy_len = MIN(val_len, val_size - 1);
+        /* If buffer length is smaller than needed, return truncation error */
+        if (copy_len < val_len) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        memcpy(val, val_ptr, copy_len);
+        val[copy_len] = '\0';
+
+        return ESP_OK;
+    }
+    ESP_LOGD(TAG, LOG_FMT("key %s not found"), key);
+    return ESP_ERR_NOT_FOUND;
+}
+
+size_t httpd_req_get_url_query_len(httpd_req_t *r)
+{
+    if (r == NULL) {
+        return 0;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return 0;
+    }
+
+    if (r->uri[0] == '\0') {
+        ESP_LOGD(TAG, "uri is empty");
+        return 0;
+    }
+
+    struct httpd_req_aux   *ra  = r->aux;
+    struct http_parser_url *res = &ra->url_parse_res;
+
+    /* Check if query field is present in the URL */
+    if (res->field_set & (1 << UF_QUERY)) {
+        return res->field_data[UF_QUERY].len;
+    }
+    return 0;
+}
+
+esp_err_t httpd_req_get_url_query_str(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    if (r == NULL || buf == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    if (r->uri[0] == '\0') {
+        ESP_LOGD(TAG, "uri is empty");
+        return ESP_FAIL;
+    }
+
+    struct httpd_req_aux   *ra  = r->aux;
+    struct http_parser_url *res = &ra->url_parse_res;
+
+    /* Check if query field is present in the URL */
+    if (res->field_set & (1 << UF_QUERY)) {
+        const char *qry = r->uri + res->field_data[UF_QUERY].off;
+
+        /* Query data length does not include terminating null */
+        size_t data_len = res->field_data[UF_QUERY].len;
+
+        /* Copy data to the caller's buffer. */
+        size_t copy_len = MIN(data_len, buf_len - 1);
+        if (copy_len < data_len) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        memcpy(buf, qry, copy_len);
+        buf[copy_len] = '\0';
+
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+/* Get the length of the value string of a header request field */
+size_t httpd_req_get_hdr_value_len(httpd_req_t *r, const char *field)
+{
+    if (r == NULL || field == NULL) {
+        return 0;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return 0;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char   *hdr_ptr = ra->scratch;         /*!< Request headers are kept in scratch buffer */
+    unsigned      count   = ra->req_hdrs_count;  /*!< Count set during parsing  */
+
+    while (count--) {
+        /* Search for the ':' character. Else, it would mean
+         * that the field is invalid
+         */
+        const char *val_ptr = strchr(hdr_ptr, ':');
+        if (!val_ptr) {
+            break;
+        }
+
+        /* If the field, does not match, continue searching.
+         * Compare lengths first as field from header is not
+         * null terminated (has ':' in the end).
+         */
+        if ((val_ptr - hdr_ptr != strlen(field)) ||
+            (strncasecmp(hdr_ptr, field, strlen(field)))) {
+            if (count) {
+                /* Jump to end of header field-value string */
+                hdr_ptr = 1 + strchr(hdr_ptr, '\0');
+
+                /* Skip all null characters (with which the line
+                 * terminators had been overwritten) */
+                while (*hdr_ptr == '\0') {
+                    hdr_ptr++;
+                }
+            }
+            continue;
+        }
+
+        /* Skip ':' */
+        val_ptr++;
+
+        /* Skip preceding space */
+        while ((*val_ptr != '\0') && (*val_ptr == ' ')) {
+            val_ptr++;
+        }
+        return strlen(val_ptr);
+    }
+    return 0;
+}
+
+/* Get the value of a field from the request headers */
+esp_err_t httpd_req_get_hdr_value_str(httpd_req_t *r, const char *field, char *val, size_t val_size)
+{
+    if (r == NULL || field == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char   *hdr_ptr = ra->scratch;         /*!< Request headers are kept in scratch buffer */
+    unsigned     count    = ra->req_hdrs_count;  /*!< Count set during parsing  */
+
+    while (count--) {
+        /* Search for the ':' character. Else, it would mean
+         * that the field is invalid
+         */
+        const char *val_ptr = strchr(hdr_ptr, ':');
+        if (!val_ptr) {
+            break;
+        }
+
+        /* If the field, does not match, continue searching.
+         * Compare lengths first as field from header is not
+         * null terminated (has ':' in the end).
+         */
+        if ((val_ptr - hdr_ptr != strlen(field)) ||
+            (strncasecmp(hdr_ptr, field, strlen(field)))) {
+            if (count) {
+                /* Jump to end of header field-value string */
+                hdr_ptr = 1 + strchr(hdr_ptr, '\0');
+
+                /* Skip all null characters (with which the line
+                 * terminators had been overwritten) */
+                while (*hdr_ptr == '\0') {
+                    hdr_ptr++;
+                }
+            }
+            continue;
+        }
+
+        /* Skip ':' */
+        val_ptr++;
+
+        /* Skip preceding space */
+        while ((*val_ptr != '\0') && (*val_ptr == ' ')) {
+            val_ptr++;
+        }
+
+        /* Get the NULL terminated value and copy it to the caller's buffer.
+         * Note `strlcpy()` will always return the size of the source string
+         * including terminimating null.*/
+        size_t full_size = strlcpy(val, val_ptr, val_size);
+
+        /* If buffer length is smaller than needed, return truncation error */
+        if (val_size < full_size) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+/* Helper function to get a cookie value from a cookie string of the type "cookie1=val1; cookie2=val2" */
+esp_err_t static httpd_cookie_key_value(const char *cookie_str, const char *key, char *val, size_t *val_size)
+{
+    if (cookie_str == NULL || key == NULL || val == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const char *cookie_ptr = cookie_str;
+
+    while (strlen(cookie_ptr)) {
+        /* Search for the '=' character. Else, it would mean
+         * that the parameter is invalid */
+        const char *val_ptr = strchr(cookie_ptr, '=');
+        if (!val_ptr) {
+            break;
+        }
+        size_t offset = val_ptr - cookie_ptr;
+
+        /* If the key, does not match, continue searching.
+         * Compare lengths first as key from cookie string is not
+         * null terminated (has '=' in the end) */
+        if ((offset != strlen(key)) || (strncasecmp(cookie_ptr, key, offset) != 0)) {
+            /* Get the name=val string. Multiple name=value pairs
+             * are separated by '; ' */
+            cookie_ptr = strchr(val_ptr, ' ');
+            if (!cookie_ptr) {
+                break;
+            }
+            cookie_ptr++;
+            continue;
+        }
+
+        /* Locate start of next query */
+        cookie_ptr = strchr(++val_ptr, ';');
+        /* Or this could be the last query, in which
+         * case get to the end of query string */
+        if (!cookie_ptr) {
+            cookie_ptr = val_ptr + strlen(val_ptr);
+        }
+
+        /* Cookie value length does not include terminating null */
+        size_t val_len = cookie_ptr - val_ptr;
+
+        /* Copy value to the caller's buffer. */
+        size_t copy_len = MIN(val_len, *val_size - 1);
+        /* If buffer length is smaller than needed, return truncation error */
+        if (copy_len < val_len) {
+            return ESP_ERR_HTTPD_RESULT_TRUNC;
+        }
+        memcpy(val, val_ptr, copy_len);
+        val[copy_len] = '\0';
+
+        /* Save actual Cookie value size (including terminating null) */
+        *val_size = copy_len + 1;
+
+        return ESP_OK;
+    }
+    ESP_LOGD(TAG, LOG_FMT("cookie %s not found"), key);
+    return ESP_ERR_NOT_FOUND;
+}
+
+/* Get the value of a cookie from the request headers */
+esp_err_t httpd_req_get_cookie_val(httpd_req_t *req, const char *cookie_name, char *val, size_t *val_size)
+{
+    esp_err_t ret;
+    size_t hdr_len_cookie = httpd_req_get_hdr_value_len(req, "Cookie");
+    char *cookie_str = NULL;
+
+    if (hdr_len_cookie <= 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    cookie_str = malloc(hdr_len_cookie + 1);
+    if (cookie_str == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate memory for cookie string");
+        return ESP_ERR_NO_MEM;
+    }
+
+    if (httpd_req_get_hdr_value_str(req, "Cookie", cookie_str, hdr_len_cookie + 1) != ESP_OK) {
+        ESP_LOGW(TAG, "Cookie not found in header uri:[%s]", req->uri);
+        free(cookie_str);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    ret = httpd_cookie_key_value(cookie_str, cookie_name, val, val_size);
+    free(cookie_str);
+    return ret;
+
+}

--- a/components/esp_http_server/src/httpd_sess.c
+++ b/components/esp_http_server/src/httpd_sess.c
@@ -1,0 +1,499 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+
+static const char *TAG = "httpd_sess";
+
+typedef enum {
+    HTTPD_TASK_NONE = 0,
+    HTTPD_TASK_INIT,            // Init session
+    HTTPD_TASK_GET_ACTIVE,      // Get active session (fd!=-1)
+    HTTPD_TASK_GET_FREE,        // Get free session slot (fd<0)
+    HTTPD_TASK_FIND_FD,         // Find session with specific fd
+    HTTPD_TASK_SET_DESCRIPTOR,  // Set descriptor
+    HTTPD_TASK_DELETE_INVALID,  // Delete invalid session
+    HTTPD_TASK_FIND_LOWEST_LRU, // Find session with lowest lru
+    HTTPD_TASK_CLOSE            // Close session
+} task_t;
+
+typedef struct {
+    task_t task;
+    int fd;
+    fd_set *fdset;
+    int max_fd;
+    struct httpd_data *hd;
+    uint64_t lru_counter;
+    struct sock_db    *session;
+} enum_context_t;
+
+void httpd_sess_enum(struct httpd_data *hd, httpd_session_enum_function enum_function, void *context)
+{
+    if ((!hd) || (!hd->hd_sd) || (!hd->config.max_open_sockets)) {
+        return;
+    }
+
+    struct sock_db *current = hd->hd_sd;
+    struct sock_db *end = hd->hd_sd + hd->config.max_open_sockets - 1;
+
+    while (current <= end) {
+        if (enum_function && (!enum_function(current, context))) {
+            break;
+        }
+        current++;
+    }
+}
+
+// Check if a FD is valid
+static int fd_is_valid(int fd)
+{
+    return fcntl(fd, F_GETFD) != -1 || errno != EBADF;
+}
+
+static int enum_function(struct sock_db *session, void *context)
+{
+    if ((!session) || (!context)) {
+        return 0;
+    }
+    enum_context_t *ctx = (enum_context_t *) context;
+    int found = 0;
+    switch (ctx->task) {
+    // Initialize session
+    case HTTPD_TASK_INIT:
+        session->fd = -1;
+        session->ctx = NULL;
+        session->for_async_req = false;
+        break;
+    // Get active session
+    case HTTPD_TASK_GET_ACTIVE:
+        found = (session->fd != -1);
+        break;
+    // Get free slot
+    case HTTPD_TASK_GET_FREE:
+        found = (session->fd < 0);
+        break;
+    // Find fd
+    case HTTPD_TASK_FIND_FD:
+        found = (session->fd == ctx->fd);
+        break;
+    // Set descriptor
+    case HTTPD_TASK_SET_DESCRIPTOR:
+        if (session->fd != -1 && !session->for_async_req) {
+            FD_SET(session->fd, ctx->fdset);
+            if (session->fd > ctx->max_fd) {
+                ctx->max_fd = session->fd;
+            }
+        }
+        break;
+    // Delete invalid session
+    case HTTPD_TASK_DELETE_INVALID:
+        if (!fd_is_valid(session->fd)) {
+            ESP_LOGW(TAG, LOG_FMT("Closing invalid socket %d"), session->fd);
+            httpd_sess_delete(ctx->hd, session);
+        }
+        break;
+    // Find lowest lru
+    case HTTPD_TASK_FIND_LOWEST_LRU:
+        // Found free slot - no need to check other sessions
+        if (session->fd == -1) {
+            return 0;
+        }
+        // Only close sockets that are not in use
+        if (session->for_async_req == false) {
+            // Check/update lowest lru
+            if (session->lru_counter < ctx->lru_counter) {
+                ctx->lru_counter = session->lru_counter;
+                ctx->session = session;
+            }
+        }
+        break;
+    case HTTPD_TASK_CLOSE:
+        if (session->fd != -1) {
+            ESP_LOGD(TAG, LOG_FMT("cleaning up socket %d"), session->fd);
+            httpd_sess_delete(ctx->hd, session);
+        }
+        break;
+    default:
+        return 0;
+    }
+    if (found) {
+        ctx->session = session;
+        return 0;
+    }
+    return 1;
+}
+
+static void httpd_sess_close(void *arg)
+{
+    struct sock_db *sock_db = (struct sock_db *) arg;
+    if (!sock_db) {
+        return;
+    }
+
+    if (!sock_db->lru_counter && !sock_db->lru_socket) {
+        ESP_LOGD(TAG, "Skipping session close for %d as it seems to be a race condition", sock_db->fd);
+        return;
+    }
+    sock_db->lru_socket = false;
+    struct httpd_data *hd = (struct httpd_data *) sock_db->handle;
+    httpd_sess_delete(hd, sock_db);
+}
+
+struct sock_db *httpd_sess_get_free(struct httpd_data *hd)
+{
+    if ((!hd) || (hd->hd_sd_active_count == hd->config.max_open_sockets)) {
+        return NULL;
+    }
+    enum_context_t context = {
+        .task = HTTPD_TASK_GET_FREE
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+    return context.session;
+}
+
+bool httpd_is_sess_available(struct httpd_data *hd)
+{
+    return httpd_sess_get_free(hd) ? true : false;
+}
+
+struct sock_db *httpd_sess_get(struct httpd_data *hd, int sockfd)
+{
+    if ((!hd) || (!hd->hd_sd) || (!hd->config.max_open_sockets)) {
+        return NULL;
+    }
+
+    // Check if called inside a request handler, and the session sockfd in use is same as the parameter
+    // => Just return the pointer to the sock_db corresponding to the request
+    if ((hd->hd_req_aux.sd) && (hd->hd_req_aux.sd->fd == sockfd)) {
+        return hd->hd_req_aux.sd;
+    }
+
+    enum_context_t context = {
+        .task = HTTPD_TASK_FIND_FD,
+        .fd = sockfd
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+    return context.session;
+}
+
+esp_err_t httpd_sess_new(struct httpd_data *hd, int newfd)
+{
+    ESP_LOGD(TAG, LOG_FMT("fd = %d"), newfd);
+
+    if (httpd_sess_get(hd, newfd)) {
+        ESP_LOGE(TAG, LOG_FMT("session already exists with fd = %d"), newfd);
+        return ESP_FAIL;
+    }
+
+    struct sock_db *session = httpd_sess_get_free(hd);
+    if (!session) {
+        ESP_LOGD(TAG, LOG_FMT("unable to launch session for fd = %d"), newfd);
+        return ESP_FAIL;
+    }
+
+    // Clear session data
+    memset(session, 0, sizeof (struct sock_db));
+    session->fd = newfd;
+    session->handle = (httpd_handle_t) hd;
+    session->send_fn = httpd_default_send;
+    session->recv_fn = httpd_default_recv;
+
+    // increment number of sessions
+    hd->hd_sd_active_count++;
+
+    // Call user-defined session opening function
+    if (hd->config.open_fn) {
+        esp_err_t ret = hd->config.open_fn(hd, session->fd);
+        if (ret != ESP_OK) {
+            httpd_sess_delete(hd, session);
+            ESP_LOGD(TAG, LOG_FMT("open_fn failed for fd = %d"), newfd);
+            return ret;
+        }
+    }
+
+
+    ESP_LOGD(TAG, LOG_FMT("active sockets: %d"), hd->hd_sd_active_count);
+    return ESP_OK;
+}
+
+void httpd_sess_free_ctx(void **ctx, httpd_free_ctx_fn_t free_fn)
+{
+    if ((!ctx) || (!*ctx)) {
+        return;
+    }
+    if (free_fn) {
+        free_fn(*ctx);
+    } else {
+        free(*ctx);
+    }
+    *ctx = NULL;
+}
+
+void httpd_sess_clear_ctx(struct sock_db *session)
+{
+    if ((!session) || ((!session->ctx) && (!session->transport_ctx))) {
+        return;
+    }
+
+    // free user ctx
+    if (session->ctx) {
+        httpd_sess_free_ctx(&session->ctx, session->free_ctx);
+        session->free_ctx = NULL;
+    }
+
+    // Free 'transport' context
+    if (session->transport_ctx) {
+        httpd_sess_free_ctx(&session->transport_ctx, session->free_transport_ctx);
+        session->free_transport_ctx = NULL;
+    }
+}
+
+void *httpd_sess_get_ctx(httpd_handle_t handle, int sockfd)
+{
+    struct sock_db *session = httpd_sess_get(handle, sockfd);
+    if (!session) {
+        return NULL;
+    }
+
+    // Check if the function has been called from inside a
+    // request handler, in which case fetch the context from
+    // the httpd_req_t structure
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd->hd_req_aux.sd == session) {
+        return hd->hd_req.sess_ctx;
+    }
+    return session->ctx;
+}
+
+void httpd_sess_set_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn)
+{
+    struct sock_db *session = httpd_sess_get(handle, sockfd);
+    if (!session) {
+        return;
+    }
+
+    // Check if the function has been called from inside a
+    // request handler, in which case set the context inside
+    // the httpd_req_t structure
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    if (hd->hd_req_aux.sd == session) {
+        if (hd->hd_req.sess_ctx != ctx) {
+            // Don't free previous context if it is in sockdb
+            // as it will be freed inside httpd_req_cleanup()
+            if (session->ctx != hd->hd_req.sess_ctx) {
+                httpd_sess_free_ctx(&hd->hd_req.sess_ctx, hd->hd_req.free_ctx); // Free previous context
+            }
+            hd->hd_req.sess_ctx = ctx;
+        }
+        hd->hd_req.free_ctx = free_fn;
+        return;
+    }
+
+    // Else set the context inside the sock_db structure
+    if (session->ctx != ctx) {
+        // Free previous context
+        httpd_sess_free_ctx(&session->ctx, session->free_ctx);
+        session->ctx = ctx;
+    }
+    session->free_ctx = free_fn;
+}
+
+void *httpd_sess_get_transport_ctx(httpd_handle_t handle, int sockfd)
+{
+    struct sock_db *session = httpd_sess_get(handle, sockfd);
+    return session ? session->transport_ctx : NULL;
+}
+
+void httpd_sess_set_transport_ctx(httpd_handle_t handle, int sockfd, void *ctx, httpd_free_ctx_fn_t free_fn)
+{
+    struct sock_db *session = httpd_sess_get(handle, sockfd);
+    if (!session) {
+        return;
+    }
+
+    if (session->transport_ctx != ctx) {
+        // Free previous transport context
+        httpd_sess_free_ctx(&session->transport_ctx, session->free_transport_ctx);
+        session->transport_ctx = ctx;
+    }
+    session->free_transport_ctx = free_fn;
+}
+
+void httpd_sess_set_descriptors(struct httpd_data *hd, fd_set *fdset, int *maxfd)
+{
+    enum_context_t context = {
+        .task = HTTPD_TASK_SET_DESCRIPTOR,
+        .max_fd = -1,
+        .fdset = fdset
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+    if (maxfd) {
+        *maxfd = context.max_fd;
+    }
+}
+
+void httpd_sess_delete_invalid(struct httpd_data *hd)
+{
+    enum_context_t context = {
+        .task = HTTPD_TASK_DELETE_INVALID,
+        .hd = hd
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+}
+
+void httpd_sess_delete(struct httpd_data *hd, struct sock_db *session)
+{
+    if ((!hd) || (!session) || (session->fd < 0)) {
+        return;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("fd = %d"), session->fd);
+    if (hd->config.enable_so_linger) {
+        struct linger so_linger = {
+            .l_onoff = true,
+            .l_linger = hd->config.linger_timeout,
+        };
+        if (setsockopt(session->fd, SOL_SOCKET, SO_LINGER, &so_linger, sizeof(struct linger)) < 0) {
+            ESP_LOGW(TAG, LOG_FMT("error enabling SO_LINGER (%d)"), errno);
+        }
+    }
+
+    // Call close function if defined
+    if (hd->config.close_fn) {
+        hd->config.close_fn(hd, session->fd);
+    } else {
+        close(session->fd);
+    }
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_DISCONNECTED, &session->fd, sizeof(int));
+
+    // clear all contexts
+    httpd_sess_clear_ctx(session);
+
+    // mark session slot as available
+    session->fd = -1;
+
+    // decrement number of sessions
+    hd->hd_sd_active_count--;
+    ESP_LOGD(TAG, LOG_FMT("active sockets: %d"), hd->hd_sd_active_count);
+    if (!hd->hd_sd_active_count) {
+        hd->lru_counter = 0;
+    }
+}
+
+void httpd_sess_init(struct httpd_data *hd)
+{
+    enum_context_t context = {
+        .task = HTTPD_TASK_INIT
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+}
+
+bool httpd_sess_pending(struct httpd_data *hd, struct sock_db *session)
+{
+    if (!session) {
+        return false;
+    }
+    if (session->pending_fn) {
+        // test if there's any data to be read (besides read() function, which is handled by select() in the main httpd loop)
+        // this should check e.g. for the SSL data buffer
+        if (session->pending_fn(hd, session->fd) > 0) {
+            return true;
+        }
+    }
+    return (session->pending_len != 0);
+}
+
+/* This MUST return ESP_OK on successful execution. If any other
+ * value is returned, everything related to this socket will be
+ * cleaned up and the socket will be closed.
+ */
+esp_err_t httpd_sess_process(struct httpd_data *hd, struct sock_db *session)
+{
+    if ((!hd) || (!session)) {
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("httpd_req_new"));
+    if (httpd_req_new(hd, session) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("httpd_req_delete"));
+    if (httpd_req_delete(hd) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    ESP_LOGD(TAG, LOG_FMT("success"));
+    session->lru_counter = ++hd->lru_counter;
+    return ESP_OK;
+}
+
+esp_err_t httpd_sess_update_lru_counter(httpd_handle_t handle, int sockfd)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+
+    enum_context_t context = {
+        .task = HTTPD_TASK_FIND_FD,
+        .fd = sockfd
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+    if (context.session) {
+        context.session->lru_counter = ++hd->lru_counter;
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t httpd_sess_close_lru(struct httpd_data *hd)
+{
+    enum_context_t context = {
+        .task = HTTPD_TASK_FIND_LOWEST_LRU,
+        .lru_counter = UINT64_MAX,
+        .fd = -1
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+    if (!context.session) {
+        return ESP_OK;
+    }
+    ESP_LOGD(TAG, LOG_FMT("Closing session with fd %d"), context.session->fd);
+    context.session->lru_socket = true;
+    return httpd_sess_trigger_close_(hd, context.session);
+}
+
+esp_err_t httpd_sess_trigger_close_(httpd_handle_t handle, struct sock_db *session)
+{
+    if (!session) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    return httpd_queue_work(handle, httpd_sess_close, session);
+}
+
+esp_err_t httpd_sess_trigger_close(httpd_handle_t handle, int sockfd)
+{
+    struct sock_db *session = httpd_sess_get(handle, sockfd);
+    if (!session) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    return httpd_sess_trigger_close_(handle, session);
+}
+
+void httpd_sess_close_all(struct httpd_data *hd)
+{
+    enum_context_t context = {
+        .task = HTTPD_TASK_CLOSE,
+        .hd = hd
+    };
+    httpd_sess_enum(hd, enum_function, &context);
+}

--- a/components/esp_http_server/src/httpd_txrx.c
+++ b/components/esp_http_server/src/httpd_txrx.c
@@ -1,0 +1,787 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_err.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+#include <netinet/tcp.h>
+
+static const char *TAG = "httpd_txrx";
+
+esp_err_t httpd_sess_set_send_override(httpd_handle_t hd, int sockfd, httpd_send_func_t send_func)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sess->send_fn = send_func;
+    return ESP_OK;
+}
+
+esp_err_t httpd_sess_set_recv_override(httpd_handle_t hd, int sockfd, httpd_recv_func_t recv_func)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sess->recv_fn = recv_func;
+    return ESP_OK;
+}
+
+esp_err_t httpd_sess_set_pending_override(httpd_handle_t hd, int sockfd, httpd_pending_func_t pending_func)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sess->pending_fn = pending_func;
+    return ESP_OK;
+}
+
+int httpd_send(httpd_req_t *r, const char *buf, size_t buf_len)
+{
+    if (r == NULL || buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    int ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+    if (ret < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in send_fn"));
+        return ret;
+    }
+    return ret;
+}
+
+static esp_err_t httpd_send_all(httpd_req_t *r, const char *buf, size_t buf_len)
+{
+    struct httpd_req_aux *ra = r->aux;
+    int ret;
+
+    while (buf_len > 0) {
+        ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+        if (ret < 0) {
+            ESP_LOGD(TAG, LOG_FMT("error in send_fn"));
+            return ESP_FAIL;
+        }
+        ESP_LOGD(TAG, LOG_FMT("sent = %d"), ret);
+        buf     += ret;
+        buf_len -= ret;
+    }
+    return ESP_OK;
+}
+
+static size_t httpd_recv_pending(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    struct httpd_req_aux *ra = r->aux;
+    size_t offset = sizeof(ra->sd->pending_data) - ra->sd->pending_len;
+
+    /* buf_len must not be greater than remaining_len */
+    buf_len = MIN(ra->sd->pending_len, buf_len);
+    memcpy(buf, ra->sd->pending_data + offset, buf_len);
+
+    ra->sd->pending_len -= buf_len;
+    return buf_len;
+}
+
+int httpd_recv_with_opt(httpd_req_t *r, char *buf, size_t buf_len, bool halt_after_pending)
+{
+    ESP_LOGD(TAG, LOG_FMT("requested length = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST(buf_len));
+
+    size_t pending_len = 0;
+    struct httpd_req_aux *ra = r->aux;
+
+    /* First fetch pending data from local buffer */
+    if (ra->sd->pending_len > 0) {
+        ESP_LOGD(TAG, LOG_FMT("pending length = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST(ra->sd->pending_len));
+        pending_len = httpd_recv_pending(r, buf, buf_len);
+        buf     += pending_len;
+        buf_len -= pending_len;
+
+        /* If buffer filled then no need to recv.
+         * If asked to halt after receiving pending data then
+         * return with received length */
+        if (!buf_len || halt_after_pending) {
+            return pending_len;
+        }
+    }
+
+    /* Receive data of remaining length */
+    int ret = ra->sd->recv_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+    if (ret < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in recv_fn"));
+        if ((ret == HTTPD_SOCK_ERR_TIMEOUT) && (pending_len != 0)) {
+            /* If recv() timeout occurred, but pending data is
+             * present, return length of pending data.
+             * This behavior is similar to that of socket recv()
+             * function, which, in case has only partially read the
+             * requested length, due to timeout, returns with read
+             * length, rather than error */
+            return pending_len;
+        }
+        return ret;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("received length = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST((ret + pending_len)));
+    return ret + pending_len;
+}
+
+int httpd_recv(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    return httpd_recv_with_opt(r, buf, buf_len, false);
+}
+
+size_t httpd_unrecv(struct httpd_req *r, const char *buf, size_t buf_len)
+{
+    struct httpd_req_aux *ra = r->aux;
+    /* Truncate if external buf_len is greater than pending_data buffer size */
+    ra->sd->pending_len = MIN(sizeof(ra->sd->pending_data), buf_len);
+
+    /* Copy data into internal pending_data buffer with the exact offset
+     * such that it is right aligned inside the buffer */
+    size_t offset = sizeof(ra->sd->pending_data) - ra->sd->pending_len;
+    memcpy(ra->sd->pending_data + offset, buf, ra->sd->pending_len);
+    ESP_LOGD(TAG, LOG_FMT("length = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST(ra->sd->pending_len));
+    return ra->sd->pending_len;
+}
+
+/**
+ * This API appends an additional header field-value pair in the HTTP response.
+ * But the header isn't sent out until any of the send APIs is executed.
+ */
+esp_err_t httpd_resp_set_hdr(httpd_req_t *r, const char *field, const char *value)
+{
+    if (r == NULL || field == NULL || value == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    struct httpd_data *hd = (struct httpd_data *) r->handle;
+
+    /* Number of additional headers is limited */
+    if (ra->resp_hdrs_count >= hd->config.max_resp_headers) {
+        return ESP_ERR_HTTPD_RESP_HDR;
+    }
+
+    /* Assign header field-value pair */
+    ra->resp_hdrs[ra->resp_hdrs_count].field = field;
+    ra->resp_hdrs[ra->resp_hdrs_count].value = value;
+    ra->resp_hdrs_count++;
+
+    ESP_LOGD(TAG, LOG_FMT("new header = %s: %s"), field, value);
+    return ESP_OK;
+}
+
+/**
+ * This API sets the status of the HTTP response to the value specified.
+ * But the status isn't sent out until any of the send APIs is executed.
+ */
+esp_err_t httpd_resp_set_status(httpd_req_t *r, const char *status)
+{
+    if (r == NULL || status == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ra->status = (char *)status;
+    return ESP_OK;
+}
+
+/**
+ * This API sets the method/type of the HTTP response to the value specified.
+ * But the method isn't sent out until any of the send APIs is executed.
+ */
+esp_err_t httpd_resp_set_type(httpd_req_t *r, const char *type)
+{
+    if (r == NULL || type == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ra->content_type = (char *)type;
+    return ESP_OK;
+}
+
+esp_err_t httpd_resp_send(httpd_req_t *r, const char *buf, ssize_t buf_len)
+{
+    if (r == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char *httpd_hdr_str = "HTTP/1.1 %s\r\nContent-Type: %s\r\nContent-Length: %d\r\n";
+    const char *colon_separator = ": ";
+    const char *cr_lf_seperator = "\r\n";
+
+    if (buf_len == HTTPD_RESP_USE_STRLEN) {
+        buf_len = strlen(buf);
+    }
+
+    /* Request headers are no longer available */
+    ra->req_hdrs_count = 0;
+
+    /* Calculate the size of the headers. +1 for the null terminator */
+    size_t required_size = snprintf(NULL, 0, httpd_hdr_str, ra->status, ra->content_type, buf_len) + 1;
+    if (required_size > ra->max_req_hdr_len) {
+        return ESP_ERR_HTTPD_RESP_HDR;
+    }
+    char *res_buf = malloc(required_size); /* Temporary buffer to store the headers */
+    if (res_buf == NULL) {
+        ESP_LOGE(TAG, "Unable to allocate httpd send buffer");
+        return ESP_ERR_HTTPD_ALLOC_MEM;
+    }
+
+    esp_err_t ret = snprintf(res_buf, required_size, httpd_hdr_str, ra->status, ra->content_type, buf_len);
+    if (ret < 0 || ret >= required_size) {
+        free(res_buf);
+        return ESP_ERR_HTTPD_RESP_HDR;
+    }
+    ESP_LOGD(TAG, "httpd send buffer size = %d", strlen(res_buf));
+    ret = httpd_send_all(r, res_buf, strlen(res_buf));
+    free(res_buf);
+    if (ret != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+
+    /* Sending additional headers based on set_header */
+    for (unsigned i = 0; i < ra->resp_hdrs_count; i++) {
+        /* Send header field */
+        if (httpd_send_all(r, ra->resp_hdrs[i].field, strlen(ra->resp_hdrs[i].field)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        /* Send ': ' */
+        if (httpd_send_all(r, colon_separator, strlen(colon_separator)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        /* Send header value */
+        if (httpd_send_all(r, ra->resp_hdrs[i].value, strlen(ra->resp_hdrs[i].value)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        /* Send CR + LF */
+        if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+    }
+
+    /* End header section */
+    if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_HEADERS_SENT, &(ra->sd->fd), sizeof(int));
+
+    /* Sending content */
+    if (buf && buf_len) {
+        if (httpd_send_all(r, buf, buf_len) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+    }
+    esp_http_server_event_data evt_data = {
+        .fd = ra->sd->fd,
+        .data_len = buf_len,
+    };
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_SENT_DATA, &evt_data, sizeof(esp_http_server_event_data));
+    return ESP_OK;
+}
+
+esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len)
+{
+    if (r == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!httpd_valid_req(r)) {
+        return ESP_ERR_HTTPD_INVALID_REQ;
+    }
+
+    if (buf_len == HTTPD_RESP_USE_STRLEN) {
+        buf_len = strlen(buf);
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    const char *httpd_chunked_hdr_str = "HTTP/1.1 %s\r\nContent-Type: %s\r\nTransfer-Encoding: chunked\r\n";
+    const char *colon_separator = ": ";
+    const char *cr_lf_seperator = "\r\n";
+
+    /* Request headers are no longer available */
+    ra->req_hdrs_count = 0;
+
+    if (!ra->first_chunk_sent) {
+        /* Calculate the size of the headers. +1 for the null terminator */
+        size_t required_size = snprintf(NULL, 0, httpd_chunked_hdr_str, ra->status, ra->content_type) + 1;
+        if (required_size > ra->max_req_hdr_len) {
+            return ESP_ERR_HTTPD_RESP_HDR;
+        }
+        char *res_buf = malloc(required_size); /* Temporary buffer to store the headers */
+        if (res_buf == NULL) {
+            ESP_LOGE(TAG, "Unable to allocate httpd send chunk buffer");
+            return ESP_ERR_HTTPD_ALLOC_MEM;
+        }
+        esp_err_t ret = snprintf(res_buf, required_size, httpd_chunked_hdr_str, ra->status, ra->content_type);
+        if (ret < 0 || ret >= required_size) {
+            free(res_buf);
+            return ESP_ERR_HTTPD_RESP_HDR;
+        }
+        ESP_LOGD(TAG, "httpd send chunk buffer size = %d", strlen(res_buf));
+        /* Size of essential headers is limited by scratch buffer size */
+        ret = httpd_send_all(r, res_buf, strlen(res_buf));
+        free(res_buf);
+        if (ret != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+
+        /* Sending additional headers based on set_header */
+        for (unsigned i = 0; i < ra->resp_hdrs_count; i++) {
+            /* Send header field */
+            if (httpd_send_all(r, ra->resp_hdrs[i].field, strlen(ra->resp_hdrs[i].field)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+            /* Send ': ' */
+            if (httpd_send_all(r, colon_separator, strlen(colon_separator)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+            /* Send header value */
+            if (httpd_send_all(r, ra->resp_hdrs[i].value, strlen(ra->resp_hdrs[i].value)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+            /* Send CR + LF */
+            if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+                return ESP_ERR_HTTPD_RESP_SEND;
+            }
+        }
+
+        /* End header section */
+        if (httpd_send_all(r, cr_lf_seperator, strlen(cr_lf_seperator)) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+        ra->first_chunk_sent = true;
+    }
+
+    /* Sending chunked content */
+    char len_str[10];
+    snprintf(len_str, sizeof(len_str), "%lx\r\n", (long)buf_len);
+    if (httpd_send_all(r, len_str, strlen(len_str)) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+
+    if (buf) {
+        if (httpd_send_all(r, buf, (size_t) buf_len) != ESP_OK) {
+            return ESP_ERR_HTTPD_RESP_SEND;
+        }
+    }
+
+    /* Indicate end of chunk */
+    if (httpd_send_all(r, "\r\n", strlen("\r\n")) != ESP_OK) {
+        return ESP_ERR_HTTPD_RESP_SEND;
+    }
+    esp_http_server_event_data evt_data = {
+        .fd = ra->sd->fd,
+        .data_len = buf_len,
+    };
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_SENT_DATA, &evt_data, sizeof(esp_http_server_event_data));
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_resp_send_err(httpd_req_t *req, httpd_err_code_t error, const char *usr_msg)
+{
+    esp_err_t ret;
+    const char *msg;
+    const char *status;
+
+    switch (error) {
+    case HTTPD_501_METHOD_NOT_IMPLEMENTED:
+        status = "501 Method Not Implemented";
+        msg    = "Server does not support this method";
+        break;
+    case HTTPD_505_VERSION_NOT_SUPPORTED:
+        status = "505 Version Not Supported";
+        msg    = "HTTP version not supported by server";
+        break;
+    case HTTPD_400_BAD_REQUEST:
+        status = "400 Bad Request";
+        msg    = "Bad request syntax";
+        break;
+    case HTTPD_401_UNAUTHORIZED:
+        status = "401 Unauthorized";
+        msg    = "No permission -- see authorization schemes";
+        break;
+    case HTTPD_403_FORBIDDEN:
+        status = "403 Forbidden";
+        msg    = "Request forbidden -- authorization will not help";
+        break;
+    case HTTPD_404_NOT_FOUND:
+        status = "404 Not Found";
+        msg    = "Nothing matches the given URI";
+        break;
+    case HTTPD_405_METHOD_NOT_ALLOWED:
+        status = "405 Method Not Allowed";
+        msg    = "Specified method is invalid for this resource";
+        break;
+    case HTTPD_408_REQ_TIMEOUT:
+        status = "408 Request Timeout";
+        msg    = "Server closed this connection";
+        break;
+    case HTTPD_414_URI_TOO_LONG:
+        status = "414 URI Too Long";
+        msg    = "URI is too long";
+        break;
+    case HTTPD_411_LENGTH_REQUIRED:
+        status = "411 Length Required";
+        msg    = "Client must specify Content-Length";
+        break;
+    case HTTPD_413_CONTENT_TOO_LARGE:
+        status = "413 Content Too Large";
+        msg    = "Content is too large";
+        break;
+    case HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE:
+        status = "431 Request Header Fields Too Large";
+        msg    = "Header fields are too long";
+        break;
+    case HTTPD_500_INTERNAL_SERVER_ERROR:
+    default:
+        status = "500 Internal Server Error";
+        msg    = "Server has encountered an unexpected error";
+    }
+
+    /* If user has provided custom message, override default message */
+    msg = usr_msg ? usr_msg : msg;
+    ESP_LOGW(TAG, LOG_FMT("%s - %s"), status, msg);
+
+    /* Set error code in HTTP response */
+    httpd_resp_set_status(req, status);
+    httpd_resp_set_type(req, HTTPD_TYPE_TEXT);
+
+#ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
+    /* Use TCP_NODELAY option to force socket to send data in buffer
+     * This ensures that the error message is sent before the socket
+     * is closed */
+    struct httpd_req_aux *ra = req->aux;
+    int nodelay = 1;
+    if (setsockopt(ra->sd->fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+        /* If failed to turn on TCP_NODELAY, throw warning and continue */
+        ESP_LOGW(TAG, LOG_FMT("error calling setsockopt : %d"), errno);
+        nodelay = 0;
+    }
+#endif
+
+    /* Send HTTP error message */
+    ret = httpd_resp_send(req, msg, HTTPD_RESP_USE_STRLEN);
+
+#ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
+    /* If TCP_NODELAY was set successfully above, time to disable it */
+    if (nodelay == 1) {
+        nodelay = 0;
+        if (setsockopt(ra->sd->fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+            /* If failed to turn off TCP_NODELAY, throw error and
+             * return failure to signal for socket closure */
+            ESP_LOGE(TAG, LOG_FMT("error calling setsockopt : %d"), errno);
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+#endif
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_ERROR, &error, sizeof(httpd_err_code_t));
+
+    return ret;
+}
+
+esp_err_t httpd_resp_send_custom_err(httpd_req_t *req, const char *status, const char *msg)
+{
+    ESP_LOGW(TAG, LOG_FMT("%s - %s"), status, msg);
+
+    /* Set error code in HTTP response */
+    httpd_resp_set_status(req, status);
+    httpd_resp_set_type(req, HTTPD_TYPE_TEXT);
+
+#ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
+    /* Use TCP_NODELAY option to force socket to send data in buffer
+     * This ensures that the error message is sent before the socket
+     * is closed */
+    struct httpd_req_aux *ra = req->aux;
+    int nodelay = 1;
+    if (setsockopt(ra->sd->fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+        /* If failed to turn on TCP_NODELAY, throw warning and continue */
+        ESP_LOGW(TAG, LOG_FMT("error calling setsockopt : %d"), errno);
+        nodelay = 0;
+    }
+#endif
+
+    /* Send HTTP error message */
+    esp_err_t ret = httpd_resp_send(req, msg, HTTPD_RESP_USE_STRLEN);
+
+#ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
+    /* If TCP_NODELAY was set successfully above, time to disable it */
+    if (nodelay == 1) {
+        nodelay = 0;
+        if (setsockopt(ra->sd->fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+            /* If failed to turn off TCP_NODELAY, throw error and
+             * return failure to signal for socket closure */
+            ESP_LOGE(TAG, LOG_FMT("error calling setsockopt : %d"), errno);
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+#endif
+    return ret;
+}
+
+esp_err_t httpd_register_err_handler(httpd_handle_t handle,
+                                     httpd_err_code_t error,
+                                     httpd_err_handler_func_t err_handler_fn)
+{
+    if (handle == NULL || error >= HTTPD_ERR_CODE_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    hd->err_handler_fns[error] = err_handler_fn;
+    return ESP_OK;
+}
+
+esp_err_t httpd_req_handle_err(httpd_req_t *req, httpd_err_code_t error)
+{
+    struct httpd_data *hd = (struct httpd_data *) req->handle;
+    esp_err_t ret;
+
+    /* Invoke custom error handler if configured */
+    if (hd->err_handler_fns[error]) {
+        ret = hd->err_handler_fns[error](req, error);
+
+        /* If error code is 500, force return failure
+         * irrespective of the handler's return value */
+        ret = (error == HTTPD_500_INTERNAL_SERVER_ERROR ? ESP_FAIL : ret);
+    } else {
+        /* If no handler is registered for this error default
+         * behavior is to send the HTTP error response and
+         * return failure for closure of underlying socket */
+        httpd_resp_send_err(req, error, NULL);
+        ret = ESP_FAIL;
+    }
+    return ret;
+}
+
+int httpd_req_recv(httpd_req_t *r, char *buf, size_t buf_len)
+{
+    if (r == NULL || buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    if (!httpd_valid_req(r)) {
+        ESP_LOGW(TAG, LOG_FMT("invalid request"));
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ESP_LOGD(TAG, LOG_FMT("remaining length = %"NEWLIB_NANO_COMPAT_FORMAT), NEWLIB_NANO_COMPAT_CAST(ra->remaining_len));
+
+    if (buf_len > ra->remaining_len) {
+        buf_len = ra->remaining_len;
+    }
+    if (buf_len == 0) {
+        return buf_len;
+    }
+
+    int ret = httpd_recv(r, buf, buf_len);
+    if (ret < 0) {
+        ESP_LOGD(TAG, LOG_FMT("error in httpd_recv"));
+        return ret;
+    }
+    ra->remaining_len -= ret;
+    ESP_LOGD(TAG, LOG_FMT("received length = %d"), ret);
+    esp_http_server_event_data evt_data = {
+        .fd = ra->sd->fd,
+        .data_len = ret,
+    };
+    esp_http_server_dispatch_event(HTTP_SERVER_EVENT_ON_DATA, &evt_data, sizeof(esp_http_server_event_data));
+    return ret;
+}
+
+esp_err_t httpd_req_async_handler_begin(httpd_req_t *r, httpd_req_t **out)
+{
+    if (r == NULL || out == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // alloc async req
+    httpd_req_t *async = malloc(sizeof(httpd_req_t));
+    if (async == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(async, r, sizeof(httpd_req_t));
+
+    // alloc async aux
+    async->aux = malloc(sizeof(struct httpd_req_aux));
+    if (async->aux == NULL) {
+        free(async);
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(async->aux, r->aux, sizeof(struct httpd_req_aux));
+
+    // Copy response header block
+    struct httpd_data *hd = (struct httpd_data *) r->handle;
+    struct httpd_req_aux *async_aux = (struct httpd_req_aux *) async->aux;
+    struct httpd_req_aux *r_aux = (struct httpd_req_aux *) r->aux;
+
+    if (r_aux->scratch) {
+        async_aux->scratch = malloc(r_aux->scratch_cur_size);
+        if (async_aux->scratch == NULL) {
+            free(async_aux);
+            free(async);
+            return ESP_ERR_NO_MEM;
+        }
+        memcpy(async_aux->scratch, r_aux->scratch, r_aux->scratch_cur_size);
+    } else {
+        async_aux->scratch = NULL;
+    }
+
+    async_aux->resp_hdrs = calloc(hd->config.max_resp_headers, sizeof(struct resp_hdr));
+    if (async_aux->resp_hdrs == NULL) {
+        free(async_aux);
+        free(async);
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(async_aux->resp_hdrs, r_aux->resp_hdrs, hd->config.max_resp_headers * sizeof(struct resp_hdr));
+
+    // Prevent the main thread from reading the rest of the request after the handler returns.
+    r_aux->remaining_len = 0;
+
+    // mark socket as "in use"
+    r_aux->sd->for_async_req = true;
+
+    *out = async;
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_req_async_handler_complete(httpd_req_t *r)
+{
+    if (r == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ra->sd->for_async_req = false;
+    free(ra->scratch);
+    ra->scratch = NULL;
+    ra->scratch_cur_size = 0;
+    ra->scratch_size_limit = 0;
+    free(ra->resp_hdrs);
+    free(r->aux);
+    free(r);
+
+    return ESP_OK;
+}
+
+int httpd_req_to_sockfd(httpd_req_t *r)
+{
+    if (r == NULL) {
+        return -1;
+    }
+
+    if (!httpd_valid_req(r)) {
+        ESP_LOGW(TAG, LOG_FMT("invalid request"));
+        return -1;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    return ra->sd->fd;
+}
+
+static int httpd_sock_err(const char *ctx, int sockfd)
+{
+    int errval;
+    ESP_LOGW(TAG, LOG_FMT("error in %s : %d"), ctx, errno);
+
+    switch (errno) {
+    case EAGAIN:
+    case EINTR:
+        errval = HTTPD_SOCK_ERR_TIMEOUT;
+        break;
+    case EINVAL:
+    case EBADF:
+    case EFAULT:
+    case ENOTSOCK:
+        errval = HTTPD_SOCK_ERR_INVALID;
+        break;
+    default:
+        errval = HTTPD_SOCK_ERR_FAIL;
+    }
+    return errval;
+}
+
+int httpd_default_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags)
+{
+    (void)hd;
+    if (buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    int ret = send(sockfd, buf, buf_len, flags);
+    if (ret < 0) {
+        return httpd_sock_err("send", sockfd);
+    }
+    return ret;
+}
+
+int httpd_default_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags)
+{
+    (void)hd;
+    if (buf == NULL) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+
+    int ret = recv(sockfd, buf, buf_len, flags);
+    if (ret < 0) {
+        return httpd_sock_err("recv", sockfd);
+    }
+    return ret;
+}
+
+int httpd_socket_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+    if (!sess->send_fn) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+    return sess->send_fn(hd, sockfd, buf, buf_len, flags);
+}
+
+int httpd_socket_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags)
+{
+    struct sock_db *sess = httpd_sess_get(hd, sockfd);
+    if (!sess) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+    if (!sess->recv_fn) {
+        return HTTPD_SOCK_ERR_INVALID;
+    }
+    return sess->recv_fn(hd, sockfd, buf, buf_len, flags);
+}

--- a/components/esp_http_server/src/httpd_uri.c
+++ b/components/esp_http_server/src/httpd_uri.c
@@ -1,0 +1,343 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <http_parser.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+
+static const char *TAG = "httpd_uri";
+
+static bool httpd_uri_match_simple(const char *uri1, const char *uri2, size_t len2)
+{
+    return strlen(uri1) == len2 &&          // First match lengths
+        (strncmp(uri1, uri2, len2) == 0);   // Then match actual URIs
+}
+
+bool httpd_uri_match_wildcard(const char *template, const char *uri, size_t len)
+{
+    const size_t tpl_len = strlen(template);
+    size_t exact_match_chars = tpl_len;
+
+    /* Check for trailing question mark and asterisk */
+    const char last = (const char) (tpl_len > 0 ? template[tpl_len - 1] : 0);
+    const char prevlast = (const char) (tpl_len > 1 ? template[tpl_len - 2] : 0);
+    const bool asterisk = last == '*' || (prevlast == '*' && last == '?');
+    const bool quest = last == '?' || (prevlast == '?' && last == '*');
+
+    /* Minimum template string length must be:
+     *      0 : if neither of '*' and '?' are present
+     *      1 : if only '*' is present
+     *      2 : if only '?' is present
+     *      3 : if both are present
+     *
+     * The expression (asterisk + quest*2) serves as a
+     * case wise generator of these length values
+     */
+
+    /* abort in cases such as "?" with no preceding character (invalid template) */
+    if (exact_match_chars < asterisk + quest*2) {
+        return false;
+    }
+
+    /* account for special characters and the optional character if "?" is used */
+    exact_match_chars -= asterisk + quest*2;
+
+    if (len < exact_match_chars) {
+        return false;
+    }
+
+    if (!quest) {
+        if (!asterisk && len != exact_match_chars) {
+            /* no special characters and different length - strncmp would return false */
+            return false;
+        }
+        /* asterisk allows arbitrary trailing characters, we ignore these using
+         * exact_match_chars as the length limit */
+        return (strncmp(template, uri, exact_match_chars) == 0);
+    } else {
+        /* question mark present */
+        if (len > exact_match_chars && template[exact_match_chars] != uri[exact_match_chars]) {
+            /* the optional character is present, but different */
+            return false;
+        }
+        if (strncmp(template, uri, exact_match_chars) != 0) {
+            /* the mandatory part differs */
+            return false;
+        }
+        /* Now we know the URI is longer than the required part of template,
+         * the mandatory part matches, and if the optional character is present, it is correct.
+         * Match is OK if we have asterisk, i.e. any trailing characters are OK, or if
+         * there are no characters beyond the optional character. */
+        return asterisk || len <= exact_match_chars + 1;
+    }
+}
+
+/* Find handler with matching URI and method, and set
+ * appropriate error code if URI or method not found */
+static httpd_uri_t* httpd_find_uri_handler(struct httpd_data *hd,
+                                           const char *uri, size_t uri_len,
+                                           httpd_method_t method,
+                                           httpd_err_code_t *err)
+{
+    if (err) {
+        *err = HTTPD_404_NOT_FOUND;
+    }
+
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] = %s"), i, hd->hd_calls[i]->uri);
+
+        /* Check if custom URI matching function is set,
+         * else use simple string compare */
+        if (hd->config.uri_match_fn ?
+            hd->config.uri_match_fn(hd->hd_calls[i]->uri, uri, uri_len) :
+            httpd_uri_match_simple(hd->hd_calls[i]->uri, uri, uri_len)) {
+            /* URIs match. Now check if method is supported */
+            if (hd->hd_calls[i]->method == method || hd->hd_calls[i]->method == HTTP_ANY) {
+                /* Match found! */
+                if (err) {
+                    /* Unset any error that may
+                     * have been set earlier */
+                    *err = 0;
+                }
+                return hd->hd_calls[i];
+            }
+            /* URI found but method not allowed.
+             * If URI is found later then this
+             * error must be set to 0 */
+            if (err) {
+                *err = HTTPD_405_METHOD_NOT_ALLOWED;
+            }
+        }
+    }
+    return NULL;
+}
+
+esp_err_t httpd_register_uri_handler(httpd_handle_t handle,
+                                     const httpd_uri_t *uri_handler)
+{
+    if (handle == NULL || uri_handler == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+
+    /* Make sure another handler with matching URI and method
+     * is not already registered. This will also catch cases
+     * when a registered URI wildcard pattern already accounts
+     * for the new URI being registered */
+    if (httpd_find_uri_handler(handle, uri_handler->uri,
+                               strlen(uri_handler->uri),
+                               uri_handler->method, NULL) != NULL) {
+        ESP_LOGW(TAG, LOG_FMT("handler %s with method %d already registered"),
+                 uri_handler->uri, uri_handler->method);
+        return ESP_ERR_HTTPD_HANDLER_EXISTS;
+    }
+
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (hd->hd_calls[i] == NULL) {
+            ESP_COMPILER_DIAGNOSTIC_PUSH_IGNORE("-Wanalyzer-malloc-leak") // False-positive detection. TODO GCC-366
+            hd->hd_calls[i] = malloc(sizeof(httpd_uri_t));
+            if (hd->hd_calls[i] == NULL) {
+                /* Failed to allocate memory */
+                return ESP_ERR_HTTPD_ALLOC_MEM;
+            }
+            ESP_COMPILER_DIAGNOSTIC_POP("-Wanalyzer-malloc-leak")
+
+            /* Copy URI string */
+            hd->hd_calls[i]->uri = strdup(uri_handler->uri);
+            if (hd->hd_calls[i]->uri == NULL) {
+                /* Failed to allocate memory */
+                free(hd->hd_calls[i]);
+                return ESP_ERR_HTTPD_ALLOC_MEM;
+            }
+
+            /* Copy remaining members */
+            hd->hd_calls[i]->method   = uri_handler->method;
+            hd->hd_calls[i]->handler  = uri_handler->handler;
+            hd->hd_calls[i]->user_ctx = uri_handler->user_ctx;
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+            hd->hd_calls[i]->is_websocket = uri_handler->is_websocket;
+            hd->hd_calls[i]->handle_ws_control_frames = uri_handler->handle_ws_control_frames;
+            if (uri_handler->supported_subprotocol) {
+                hd->hd_calls[i]->supported_subprotocol = strdup(uri_handler->supported_subprotocol);
+                if (hd->hd_calls[i]->supported_subprotocol == NULL) {
+                    /* Failed to allocate memory */
+                    free((void *)hd->hd_calls[i]->uri);
+                    free(hd->hd_calls[i]);
+                    return ESP_ERR_HTTPD_ALLOC_MEM;
+                }
+            } else {
+                hd->hd_calls[i]->supported_subprotocol = NULL;
+            }
+#endif
+            ESP_LOGD(TAG, LOG_FMT("[%d] installed %s"), i, uri_handler->uri);
+            return ESP_OK;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] exists %s"), i, hd->hd_calls[i]->uri);
+    }
+    ESP_LOGW(TAG, LOG_FMT("no slots left for registering handler"));
+    return ESP_ERR_HTTPD_HANDLERS_FULL;
+}
+
+esp_err_t httpd_unregister_uri_handler(httpd_handle_t handle,
+                                       const char *uri, httpd_method_t method)
+{
+    if (handle == NULL || uri == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        if ((hd->hd_calls[i]->method == method) &&       // First match methods
+            (strcmp(hd->hd_calls[i]->uri, uri) == 0)) {  // Then match URI string
+            ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, hd->hd_calls[i]->uri);
+
+            free((char*)hd->hd_calls[i]->uri);
+            free(hd->hd_calls[i]);
+            hd->hd_calls[i] = NULL;
+
+            /* Shift the remaining non null handlers in the array
+             * forward by 1 so that order of insertion is maintained */
+            for (i += 1; i < hd->config.max_uri_handlers; i++) {
+                if (!hd->hd_calls[i]) {
+                    break;
+                }
+                hd->hd_calls[i-1] = hd->hd_calls[i];
+            }
+            /* Nullify the following non null entry */
+            hd->hd_calls[i-1] = NULL;
+            return ESP_OK;
+        }
+    }
+    ESP_LOGW(TAG, LOG_FMT("handler %s with method %d not found"), uri, method);
+    return ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t httpd_unregister_uri(httpd_handle_t handle, const char *uri)
+{
+    if (handle == NULL || uri == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_data *hd = (struct httpd_data *) handle;
+    bool found = false;
+
+    int i = 0, j = 0; // For keeping count of removed entries
+    for (; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        if (strcmp(hd->hd_calls[i]->uri, uri) == 0) {   // Match URI strings
+            ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, uri);
+
+            free((char*)hd->hd_calls[i]->uri);
+            free(hd->hd_calls[i]);
+            hd->hd_calls[i] = NULL;
+            found = true;
+
+            j++; // Update count of removed entries
+        } else {
+            /* Shift the remaining non null handlers in the array
+             * forward by j so that order of insertion is maintained */
+            hd->hd_calls[i-j] = hd->hd_calls[i];
+        }
+    }
+    /* Nullify the following non null entries */
+    for (int k = (i - j); k < i; k++) {
+        hd->hd_calls[k] = NULL;
+    }
+
+    if (!found) {
+        ESP_LOGW(TAG, LOG_FMT("no handler found for URI %s"), uri);
+    }
+    return (found ? ESP_OK : ESP_ERR_NOT_FOUND);
+}
+
+void httpd_unregister_all_uri_handlers(struct httpd_data *hd)
+{
+    for (unsigned i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, hd->hd_calls[i]->uri);
+
+        free((char*)hd->hd_calls[i]->uri);
+        free(hd->hd_calls[i]);
+        hd->hd_calls[i] = NULL;
+    }
+}
+
+esp_err_t httpd_uri(struct httpd_data *hd)
+{
+    httpd_uri_t            *uri = NULL;
+    httpd_req_t            *req = &hd->hd_req;
+    struct http_parser_url *res = &hd->hd_req_aux.url_parse_res;
+
+    /* For conveying URI not found/method not allowed */
+    httpd_err_code_t err = 0;
+
+    ESP_LOGD(TAG, LOG_FMT("request for %s with type %d"), req->uri, req->method);
+
+    /* URL parser result contains offset and length of path string */
+    if (res->field_set & (1 << UF_PATH)) {
+        uri = httpd_find_uri_handler(hd, req->uri + res->field_data[UF_PATH].off,
+                                     res->field_data[UF_PATH].len, req->method, &err);
+    }
+
+    /* If URI with method not found, respond with error code */
+    if (uri == NULL) {
+        switch (err) {
+            case HTTPD_404_NOT_FOUND:
+                ESP_LOGW(TAG, LOG_FMT("URI '%s' not found"), req->uri);
+                return httpd_req_handle_err(req, HTTPD_404_NOT_FOUND);
+            case HTTPD_405_METHOD_NOT_ALLOWED:
+                ESP_LOGW(TAG, LOG_FMT("Method '%d' not allowed for URI '%s'"),
+                         req->method, req->uri);
+                return httpd_req_handle_err(req, HTTPD_405_METHOD_NOT_ALLOWED);
+            default:
+                return ESP_FAIL;
+        }
+    }
+
+    /* Attach user context data (passed during URI registration) into request */
+    req->user_ctx = uri->user_ctx;
+
+    /* Final step for a WebSocket handshake verification */
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+    struct httpd_req_aux   *aux = req->aux;
+    if (uri->is_websocket && aux->ws_handshake_detect && uri->method == HTTP_GET) {
+        ESP_LOGD(TAG, LOG_FMT("Responding WS handshake to sock %d"), aux->sd->fd);
+        esp_err_t ret = httpd_ws_respond_server_handshake(&hd->hd_req, uri->supported_subprotocol);
+        if (ret != ESP_OK) {
+            return ret;
+        }
+
+        aux->sd->ws_handshake_done = true;
+        aux->sd->ws_handler = uri->handler;
+        aux->sd->ws_control_frames = uri->handle_ws_control_frames;
+        aux->sd->ws_user_ctx = uri->user_ctx;
+    }
+#endif
+
+    /* Invoke handler */
+    if (uri->handler(req) != ESP_OK) {
+        /* Handler returns error, this socket should be closed */
+        ESP_LOGW(TAG, LOG_FMT("uri handler execution failed"));
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}

--- a/components/esp_http_server/src/httpd_ws.c
+++ b/components/esp_http_server/src/httpd_ws.c
@@ -1,0 +1,632 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/random.h>
+#include <esp_log.h>
+#include <esp_err.h>
+#include <mbedtls/sha1.h>
+#include <mbedtls/base64.h>
+#include <mbedtls/error.h>
+
+#include <esp_http_server.h>
+#include "esp_httpd_priv.h"
+#include "freertos/event_groups.h"
+#include "sdkconfig.h"
+
+#ifdef CONFIG_HTTPD_WS_SUPPORT
+
+#define WS_SEND_OK      (1 << 0)
+#define WS_SEND_FAILED  (1 << 1)
+
+typedef struct {
+    httpd_ws_frame_t frame;
+    httpd_handle_t handle;
+    int socket;
+    transfer_complete_cb callback;
+    void *arg;
+    bool blocking;
+    EventGroupHandle_t transfer_done;
+} async_transfer_t;
+
+static const char *TAG="httpd_ws";
+
+/*
+ * Bit masks for WebSocket frames.
+ * Please refer to RFC6455 Section 5.2 for more details.
+ */
+#define HTTPD_WS_CONTINUE       0x00U
+#define HTTPD_WS_FIN_BIT        0x80U
+#define HTTPD_WS_OPCODE_BITS    0x0fU
+#define HTTPD_WS_MASK_BIT       0x80U
+#define HTTPD_WS_LENGTH_BITS    0x7fU
+
+/*
+ * The magic GUID string used for handshake
+ * Please refer to RFC6455 Section 1.3 for more details.
+ */
+static const char ws_magic_uuid[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/* Checks if any subprotocols from the comma separated list matches the supported one
+ *
+ * Returns true if the response should contain a protocol field
+*/
+
+/**
+ * @brief Checks if any subprotocols from the comma separated list matches the supported one
+ *
+ * @param supported_subprotocol[in] The subprotocol supported by the URI
+ * @param subprotocol[in],  [in]: A comma separate list of subprotocols requested
+ * @param buf_len Length of the buffer
+ * @return true: found a matching subprotocol
+ * @return false
+ */
+static bool httpd_ws_get_response_subprotocol(const char *supported_subprotocol, char *subprotocol, size_t buf_len)
+{
+    /* Request didn't contain any subprotocols */
+    if (strnlen(subprotocol, buf_len) == 0) {
+        return false;
+    }
+
+    if (supported_subprotocol == NULL) {
+        ESP_LOGW(TAG, "Sec-WebSocket-Protocol %s not supported, URI do not support any subprotocols", subprotocol);
+        return false;
+    }
+
+    /* Get first subprotocol from comma separated list */
+    char *rest = NULL;
+    char *s = strtok_r(subprotocol, ", ", &rest);
+    do {
+        if (strncmp(s, supported_subprotocol, sizeof(subprotocol)) == 0) {
+            ESP_LOGD(TAG, "Requested subprotocol supported: %s", s);
+            return true;
+        }
+    } while ((s = strtok_r(NULL, ", ", &rest)) != NULL);
+
+    ESP_LOGW(TAG, "Sec-WebSocket-Protocol %s not supported, supported subprotocol is %s", subprotocol, supported_subprotocol);
+
+    /* No matches */
+    return false;
+
+}
+
+esp_err_t httpd_ws_respond_server_handshake(httpd_req_t *req, const char *supported_subprotocol)
+{
+    /* Probe if input parameters are valid or not */
+    if (!req || !req->aux) {
+        ESP_LOGW(TAG, LOG_FMT("Argument is invalid"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Detect handshake - reject if handshake was ALREADY performed */
+    struct httpd_req_aux *req_aux = req->aux;
+    if (req_aux->sd->ws_handshake_done) {
+        ESP_LOGW(TAG, LOG_FMT("State is invalid - Handshake has been performed"));
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Detect WS version existence */
+    char version_val[3] = { '\0' };
+    if (httpd_req_get_hdr_value_str(req, "Sec-WebSocket-Version", version_val, sizeof(version_val)) != ESP_OK) {
+        ESP_LOGW(TAG, LOG_FMT("\"Sec-WebSocket-Version\" is not found"));
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    /* Detect if WS version is "13" or not.
+     * WS version must be 13 for now. Please refer to RFC6455 Section 4.1, Page 18 for more details. */
+    if (strcasecmp(version_val, "13") != 0) {
+        ESP_LOGW(TAG, LOG_FMT("\"Sec-WebSocket-Version\" is not \"13\", it is: %s"), version_val);
+        return ESP_ERR_INVALID_VERSION;
+    }
+
+    /* Grab Sec-WebSocket-Key (client key) from the header */
+    /* Size of base64 coded string is equal '((input_size * 4) / 3) + (input_size / 96) + 6' including Z-term */
+    char sec_key_encoded[28] = { '\0' };
+    if (httpd_req_get_hdr_value_str(req, "Sec-WebSocket-Key", sec_key_encoded, sizeof(sec_key_encoded)) != ESP_OK) {
+        ESP_LOGW(TAG, LOG_FMT("Cannot find client key"));
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    /* Prepare server key (Sec-WebSocket-Accept), concat the string */
+    char server_key_encoded[33] = { '\0' };
+    uint8_t server_key_hash[20] = { 0 };
+    char server_raw_text[sizeof(sec_key_encoded) + sizeof(ws_magic_uuid) + 1] = { '\0' };
+
+    strcpy(server_raw_text, sec_key_encoded);
+    strcat(server_raw_text, ws_magic_uuid);
+
+    ESP_LOGD(TAG, LOG_FMT("Server key before encoding: %s"), server_raw_text);
+
+    /* Generate SHA-1 first and then encode to Base64 */
+    size_t key_len = strlen(server_raw_text);
+
+#if CONFIG_MBEDTLS_SHA1_C || CONFIG_MBEDTLS_HARDWARE_SHA
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    mbedtls_sha1_context ctx;
+    mbedtls_sha1_init(&ctx);
+
+    if ((ret = mbedtls_sha1_starts(&ctx)) != 0) {
+        goto sha_end;
+    }
+
+    if ((ret = mbedtls_sha1_update(&ctx, (uint8_t *)server_raw_text, key_len)) != 0) {
+        goto sha_end;
+    }
+
+    if ((ret = mbedtls_sha1_finish(&ctx, server_key_hash)) != 0) {
+        goto sha_end;
+    }
+
+sha_end:
+    mbedtls_sha1_free(&ctx);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Error in calculating SHA1 sum , returned 0x%02X", ret);
+        return ESP_FAIL;
+    }
+#else
+    ESP_LOGE(TAG, "Please enable CONFIG_MBEDTLS_SHA1_C or CONFIG_MBEDTLS_HARDWARE_SHA to support SHA1 operations");
+    return ESP_FAIL;
+#endif /* CONFIG_MBEDTLS_SHA1_C || CONFIG_MBEDTLS_HARDWARE_SHA */
+
+    size_t encoded_len = 0;
+    mbedtls_base64_encode((uint8_t *)server_key_encoded, sizeof(server_key_encoded), &encoded_len,
+                          server_key_hash, sizeof(server_key_hash));
+
+    ESP_LOGD(TAG, LOG_FMT("Generated server key: %s"), server_key_encoded);
+
+    char subprotocol[50] = { '\0' };
+    if (httpd_req_get_hdr_value_str(req, "Sec-WebSocket-Protocol", subprotocol, sizeof(subprotocol) - 1) == ESP_ERR_HTTPD_RESULT_TRUNC) {
+        ESP_LOGW(TAG, "Sec-WebSocket-Protocol length exceeded buffer size of %"NEWLIB_NANO_COMPAT_FORMAT", was truncated", NEWLIB_NANO_COMPAT_CAST(sizeof(subprotocol)));
+    }
+
+
+    /* Prepare the Switching Protocol response */
+    char tx_buf[192] = { '\0' };
+    int fmt_len = snprintf(tx_buf, sizeof(tx_buf),
+                           "HTTP/1.1 101 Switching Protocols\r\n"
+                           "Upgrade: websocket\r\n"
+                           "Connection: Upgrade\r\n"
+                           "Sec-WebSocket-Accept: %s\r\n", server_key_encoded);
+
+    if (fmt_len < 0 || fmt_len > sizeof(tx_buf)) {
+        ESP_LOGW(TAG, LOG_FMT("Failed to prepare Tx buffer"));
+        return ESP_FAIL;
+    }
+
+    if ( httpd_ws_get_response_subprotocol(supported_subprotocol, subprotocol, sizeof(subprotocol))) {
+        ESP_LOGD(TAG, "subprotocol: %s", subprotocol);
+        int r = snprintf(tx_buf + fmt_len, sizeof(tx_buf) - fmt_len, "Sec-WebSocket-Protocol: %s\r\n", supported_subprotocol);
+        if (r <= 0) {
+            ESP_LOGE(TAG, "Error in response generation"
+                          "(snprintf of subprotocol returned %d, buffer size: %"NEWLIB_NANO_COMPAT_FORMAT, r, NEWLIB_NANO_COMPAT_CAST(sizeof(tx_buf)));
+            return ESP_FAIL;
+        }
+
+        fmt_len += r;
+
+        if (fmt_len >= sizeof(tx_buf)) {
+            ESP_LOGE(TAG, "Error in response generation"
+                          "(snprintf of subprotocol returned %d, desired response len: %d, buffer size: %"NEWLIB_NANO_COMPAT_FORMAT, r, fmt_len, NEWLIB_NANO_COMPAT_CAST(sizeof(tx_buf)));
+            return ESP_FAIL;
+        }
+    }
+
+    int r = snprintf(tx_buf + fmt_len, sizeof(tx_buf) - fmt_len, "\r\n");
+    if (r <= 0) {
+        ESP_LOGE(TAG, "Error in response generation"
+                        "(snprintf of subprotocol returned %d, buffer size: %"NEWLIB_NANO_COMPAT_FORMAT, r, NEWLIB_NANO_COMPAT_CAST(sizeof(tx_buf)));
+        return ESP_FAIL;
+    }
+    fmt_len += r;
+    if (fmt_len >= sizeof(tx_buf)) {
+        ESP_LOGE(TAG, "Error in response generation"
+                       "(snprintf of header terminal returned %d, desired response len: %d, buffer size: %"NEWLIB_NANO_COMPAT_FORMAT, r, fmt_len, NEWLIB_NANO_COMPAT_CAST(sizeof(tx_buf)));
+        return ESP_FAIL;
+    }
+
+    /* Send off the response */
+    if (httpd_send(req, tx_buf, fmt_len) < 0) {
+        ESP_LOGW(TAG, LOG_FMT("Failed to send the response"));
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t httpd_ws_check_req(httpd_req_t *req)
+{
+    /* Probe if input parameters are valid or not */
+    if (!req || !req->aux) {
+        ESP_LOGW(TAG, LOG_FMT("Argument is null"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Detect handshake - reject if handshake was NOT YET performed */
+    struct httpd_req_aux *req_aux = req->aux;
+    if (!req_aux->sd->ws_handshake_done) {
+        ESP_LOGW(TAG, LOG_FMT("State is invalid - No handshake performed"));
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t httpd_ws_unmask_payload(uint8_t *payload, size_t len, const uint8_t *mask_key)
+{
+    if (len < 1 || !payload) {
+        ESP_LOGW(TAG, LOG_FMT("Invalid payload provided"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    for (size_t idx = 0; idx < len; idx++) {
+        payload[idx] = (payload[idx] ^ mask_key[idx % 4]);
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t max_len)
+{
+    esp_err_t ret = httpd_ws_check_req(req);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    struct httpd_req_aux *aux = req->aux;
+    if (aux == NULL) {
+        ESP_LOGW(TAG, LOG_FMT("Invalid Aux pointer"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!frame) {
+        ESP_LOGW(TAG, LOG_FMT("Frame pointer is invalid"));
+        return ESP_ERR_INVALID_ARG;
+    }
+    /* If frame len is 0, will get frame len from req. Otherwise regard frame len already achieved by calling httpd_ws_recv_frame before */
+    if (frame->len == 0) {
+        /* Assign the frame info from the previous reading */
+        frame->type = aux->ws_type;
+        frame->final = aux->ws_final;
+
+        /* Grab the second byte */
+        uint8_t second_byte = 0;
+        if (httpd_recv_with_opt(req, (char *)&second_byte, sizeof(second_byte), false) <= 0) {
+            ESP_LOGW(TAG, LOG_FMT("Failed to receive the second byte"));
+            return ESP_FAIL;
+        }
+
+        /* Parse the second byte */
+        /* Please refer to RFC6455 Section 5.2 for more details */
+        bool masked = (second_byte & HTTPD_WS_MASK_BIT) != 0;
+
+        /* Interpret length */
+        uint8_t init_len = second_byte & HTTPD_WS_LENGTH_BITS;
+        if (init_len < 126) {
+            /* Case 1: If length is 0-125, then this length bit is 7 bits */
+            frame->len = init_len;
+        } else if (init_len == 126) {
+            /* Case 2: If length byte is 126, then this frame's length bit is 16 bits */
+            uint8_t length_bytes[2] = { 0 };
+            if (httpd_recv_with_opt(req, (char *)length_bytes, sizeof(length_bytes), false) <= 0) {
+                ESP_LOGW(TAG, LOG_FMT("Failed to receive 2 bytes length"));
+                return ESP_FAIL;
+            }
+
+            frame->len = ((uint32_t)(length_bytes[0] << 8U) | (length_bytes[1]));
+        } else if (init_len == 127) {
+            /* Case 3: If length is byte 127, then this frame's length bit is 64 bits */
+            uint8_t length_bytes[8] = { 0 };
+            if (httpd_recv_with_opt(req, (char *)length_bytes, sizeof(length_bytes), false) <= 0) {
+                ESP_LOGW(TAG, LOG_FMT("Failed to receive 2 bytes length"));
+                return ESP_FAIL;
+            }
+
+            frame->len = (((uint64_t)length_bytes[0] << 56U) |
+                    ((uint64_t)length_bytes[1] << 48U) |
+                    ((uint64_t)length_bytes[2] << 40U) |
+                    ((uint64_t)length_bytes[3] << 32U) |
+                    ((uint64_t)length_bytes[4] << 24U) |
+                    ((uint64_t)length_bytes[5] << 16U) |
+                    ((uint64_t)length_bytes[6] <<  8U) |
+                    ((uint64_t)length_bytes[7]));
+        }
+        /* If this frame is masked, dump the mask as well */
+        if (masked) {
+            if (httpd_recv_with_opt(req, (char *)aux->mask_key, sizeof(aux->mask_key), false) <= 0) {
+                ESP_LOGW(TAG, LOG_FMT("Failed to receive mask key"));
+                return ESP_FAIL;
+            }
+        } else {
+            /* If the WS frame from client to server is not masked, it should be rejected.
+             * Please refer to RFC6455 Section 5.2 for more details. */
+            ESP_LOGW(TAG, LOG_FMT("WS frame is not properly masked."));
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+    /* We only accept the incoming packet length that is smaller than the max_len (or it will overflow the buffer!) */
+    /* If max_len is 0, regard it OK for userspace to get frame len */
+    if (frame->len > max_len) {
+        if (max_len == 0) {
+            ESP_LOGD(TAG, "regard max_len == 0 is OK for user to get frame len");
+            return ESP_OK;
+        }
+        ESP_LOGW(TAG, LOG_FMT("WS Message too long"));
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    /* Receive buffer */
+    /* If there's nothing to receive, return and stop here. */
+    if (frame->len == 0) {
+        return ESP_OK;
+    }
+
+    if (frame->payload == NULL) {
+        ESP_LOGW(TAG, LOG_FMT("Payload buffer is null"));
+        return ESP_FAIL;
+    }
+
+    size_t left_len = frame->len;
+    size_t offset = 0;
+
+    while (left_len > 0) {
+        int read_len = httpd_recv_with_opt(req, (char *)frame->payload + offset, left_len, false);
+        if (read_len <= 0) {
+            ESP_LOGW(TAG, LOG_FMT("Failed to receive payload"));
+            return ESP_FAIL;
+        }
+        offset += read_len;
+        left_len -= read_len;
+
+        ESP_LOGD(TAG, "Frame length: %"NEWLIB_NANO_COMPAT_FORMAT", Bytes Read: %"NEWLIB_NANO_COMPAT_FORMAT, NEWLIB_NANO_COMPAT_CAST(frame->len), NEWLIB_NANO_COMPAT_CAST(offset));
+    }
+
+    /* Unmask payload */
+    httpd_ws_unmask_payload(frame->payload, frame->len, aux->mask_key);
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_ws_send_frame(httpd_req_t *req, httpd_ws_frame_t *frame)
+{
+    esp_err_t ret = httpd_ws_check_req(req);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    return httpd_ws_send_frame_async(req->handle, httpd_req_to_sockfd(req), frame);
+}
+
+esp_err_t httpd_ws_send_frame_async(httpd_handle_t hd, int fd, httpd_ws_frame_t *frame)
+{
+    if (!frame) {
+        ESP_LOGW(TAG, LOG_FMT("Argument is invalid"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Prepare Tx buffer - maximum length is 14, which includes 2 bytes header, 8 bytes length, 4 bytes mask key */
+    uint8_t tx_len = 0;
+    uint8_t header_buf[10] = {0 };
+    /* Set the `FIN` bit by default if message is not fragmented. Else, set it as per the `final` field */
+    header_buf[0] |= (!frame->fragmented) ? HTTPD_WS_FIN_BIT : (frame->final? HTTPD_WS_FIN_BIT: HTTPD_WS_CONTINUE);
+    header_buf[0] |= frame->type; /* Type (opcode): 4 bits */
+
+    if (frame->len <= 125) {
+        header_buf[1] = frame->len & 0x7fU; /* Length for 7 bits */
+        tx_len = 2;
+    } else if (frame->len > 125 && frame->len < UINT16_MAX) {
+        header_buf[1] = 126;                /* Length for 16 bits */
+        header_buf[2] = (frame->len >> 8U) & 0xffU;
+        header_buf[3] = frame->len & 0xffU;
+        tx_len = 4;
+    } else {
+        header_buf[1] = 127;                /* Length for 64 bits */
+        uint8_t shift_idx = sizeof(uint64_t) - 1; /* Shift index starts at 7 */
+        uint64_t len64 = frame->len; /* Raise variable size to make sure we won't shift by more bits
+                                      * than the length has (to avoid undefined behaviour) */
+        for (int8_t idx = 2; idx <= 9; idx++) {
+            /* Now do shifting (be careful of endianness, i.e. when buffer index is 2, frame length shift index is 7) */
+            header_buf[idx] = (len64 >> (shift_idx * 8)) & 0xffU;
+            shift_idx--;
+        }
+        tx_len = 10;
+    }
+
+    /* WebSocket server does not required to mask response payload, so leave the MASK bit as 0. */
+    header_buf[1] &= (~HTTPD_WS_MASK_BIT);
+
+    struct sock_db *sess = httpd_sess_get(hd, fd);
+    if (!sess) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Send off header */
+    if (sess->send_fn(hd, fd, (const char *)header_buf, tx_len, 0) < 0) {
+        ESP_LOGW(TAG, LOG_FMT("Failed to send WS header"));
+        return ESP_FAIL;
+    }
+
+    /* Send off payload */
+    if(frame->len > 0 && frame->payload != NULL) {
+        if (sess->send_fn(hd, fd, (const char *)frame->payload, frame->len, 0) < 0) {
+            ESP_LOGW(TAG, LOG_FMT("Failed to send WS payload"));
+            return ESP_FAIL;
+        }
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_ws_get_frame_type(httpd_req_t *req)
+{
+    esp_err_t ret = httpd_ws_check_req(req);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    struct httpd_req_aux *aux = req->aux;
+    if (aux == NULL) {
+        ESP_LOGW(TAG, LOG_FMT("Invalid Aux pointer"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct sock_db *sd = aux->sd;
+    if (sd == NULL) {
+        ESP_LOGW(TAG, LOG_FMT("Invalid sd pointer"));
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Read the first byte from the frame to get the FIN flag and Opcode */
+    /* Please refer to RFC6455 Section 5.2 for more details */
+    uint8_t first_byte = 0;
+    if (httpd_recv_with_opt(req, (char *)&first_byte, sizeof(first_byte), false) <= 0) {
+        /* If the recv() return code is <= 0, then this socket FD is invalid (i.e. a broken connection) */
+        /* Here we mark it as a Close message and close it later. */
+        ESP_LOGW(TAG, LOG_FMT("Failed to read header byte (socket FD invalid), closing socket now"));
+        aux->ws_final = true;
+        aux->ws_type = HTTPD_WS_TYPE_CLOSE;
+        return ESP_OK;
+    }
+
+    ESP_LOGD(TAG, LOG_FMT("First byte received: 0x%02X"), first_byte);
+
+    /* Decode the FIN flag and Opcode from the byte */
+    aux->ws_final = (first_byte & HTTPD_WS_FIN_BIT) != 0;
+    aux->ws_type = (first_byte & HTTPD_WS_OPCODE_BITS);
+
+    /* If userspace requests control frames, do not deal with the control frames */
+    if (!sd->ws_control_frames) {
+        ESP_LOGD(TAG, LOG_FMT("Handler not requests control frames"));
+
+        /* Reply to PING. For PONG and CLOSE, it will be handled elsewhere. */
+        if (aux->ws_type == HTTPD_WS_TYPE_PING) {
+            ESP_LOGD(TAG, LOG_FMT("Got a WS PING frame, Replying PONG..."));
+
+            /* Read the rest of the PING frame, for PONG to reply back. */
+            /* Please refer to RFC6455 Section 5.5.2 for more details */
+            httpd_ws_frame_t frame;
+            uint8_t frame_buf[128] = { 0 };
+            memset(&frame, 0, sizeof(httpd_ws_frame_t));
+            frame.payload = frame_buf;
+
+            if (httpd_ws_recv_frame(req, &frame, 126) != ESP_OK) {
+                ESP_LOGD(TAG, LOG_FMT("Cannot receive the full PING frame"));
+                return ESP_ERR_INVALID_STATE;
+            }
+
+            /* Now turn the frame to PONG */
+            frame.type = HTTPD_WS_TYPE_PONG;
+            return httpd_ws_send_frame(req, &frame);
+        } else if (aux->ws_type == HTTPD_WS_TYPE_CLOSE) {
+            ESP_LOGD(TAG, LOG_FMT("Got a WS CLOSE frame, Replying CLOSE..."));
+
+            /* Read the rest of the CLOSE frame and response */
+            /* Please refer to RFC6455 Section 5.5.1 for more details */
+            httpd_ws_frame_t frame;
+            uint8_t frame_buf[128] = { 0 };
+            memset(&frame, 0, sizeof(httpd_ws_frame_t));
+            frame.payload = frame_buf;
+
+            if (httpd_ws_recv_frame(req, &frame, 126) != ESP_OK) {
+                ESP_LOGD(TAG, LOG_FMT("Cannot receive the full CLOSE frame"));
+                return ESP_ERR_INVALID_STATE;
+            }
+
+            frame.len = 0;
+            frame.type = HTTPD_WS_TYPE_CLOSE;
+            frame.payload = NULL;
+            return httpd_ws_send_frame(req, &frame);
+        }
+    }
+    return ESP_OK;
+}
+
+httpd_ws_client_info_t httpd_ws_get_fd_info(httpd_handle_t hd, int fd)
+{
+    struct sock_db *sess = httpd_sess_get(hd, fd);
+
+    if (sess == NULL) {
+        return HTTPD_WS_CLIENT_INVALID;
+    }
+    bool is_active_ws = sess->ws_handshake_done && (!sess->ws_close);
+    return is_active_ws ? HTTPD_WS_CLIENT_WEBSOCKET : HTTPD_WS_CLIENT_HTTP;
+}
+
+static void httpd_ws_send_cb(void *arg)
+{
+    async_transfer_t *trans = arg;
+
+    esp_err_t err = httpd_ws_send_frame_async(trans->handle, trans->socket, &trans->frame);
+
+    if (trans->blocking) {
+        xEventGroupSetBits(trans->transfer_done, err ? WS_SEND_FAILED : WS_SEND_OK);
+    } else if (trans->callback) {
+        trans->callback(err, trans->socket, trans->arg);
+    }
+
+    free(trans);
+}
+
+esp_err_t httpd_ws_send_data(httpd_handle_t handle, int socket, httpd_ws_frame_t *frame)
+{
+    async_transfer_t *transfer = calloc(1, sizeof(async_transfer_t));
+    if (transfer == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    EventGroupHandle_t transfer_done = xEventGroupCreate();
+    if (!transfer_done) {
+        free(transfer);
+        return ESP_ERR_NO_MEM;
+    }
+
+    transfer->blocking = true;
+    transfer->handle = handle;
+    transfer->socket = socket;
+    transfer->transfer_done = transfer_done;
+    memcpy(&transfer->frame, frame, sizeof(httpd_ws_frame_t));
+
+    esp_err_t err = httpd_queue_work(handle, httpd_ws_send_cb, transfer);
+    if (err != ESP_OK) {
+        vEventGroupDelete(transfer_done);
+        free(transfer);
+        return err;
+    }
+
+    EventBits_t status = xEventGroupWaitBits(transfer_done, WS_SEND_OK | WS_SEND_FAILED,
+                                             pdTRUE, pdFALSE, portMAX_DELAY);
+
+    vEventGroupDelete(transfer_done);
+
+    return (status & WS_SEND_OK) ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t httpd_ws_send_data_async(httpd_handle_t handle, int socket, httpd_ws_frame_t *frame,
+                                   transfer_complete_cb callback, void *arg)
+{
+    async_transfer_t *transfer = calloc(1, sizeof(async_transfer_t));
+    if (transfer == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    transfer->arg = arg;
+    transfer->callback = callback;
+    transfer->handle = handle;
+    transfer->socket = socket;
+    memcpy(&transfer->frame, frame, sizeof(httpd_ws_frame_t));
+
+    esp_err_t err = httpd_queue_work(handle, httpd_ws_send_cb, transfer);
+
+    if (err) {
+        free(transfer);
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+#endif /* CONFIG_HTTPD_WS_SUPPORT */

--- a/components/esp_http_server/src/port/esp32/osal.h
+++ b/components/esp_http_server/src/port/esp32/osal.h
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _OSAL_H_
+#define _OSAL_H_
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <esp_timer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OS_SUCCESS ESP_OK
+#define OS_FAIL    ESP_FAIL
+
+typedef TaskHandle_t othread_t;
+
+static inline int httpd_os_thread_create(othread_t *thread,
+                                 const char *name, uint16_t stacksize, int prio,
+                                 void (*thread_routine)(void *arg), void *arg,
+                                 BaseType_t core_id, uint32_t caps)
+{
+    int ret = xTaskCreatePinnedToCoreWithCaps(thread_routine, name, stacksize, arg, prio, thread, core_id, caps);
+    if (ret == pdPASS) {
+        return OS_SUCCESS;
+    }
+    return OS_FAIL;
+}
+
+/* Only self delete is supported */
+static inline void httpd_os_thread_delete(void)
+{
+    vTaskDeleteWithCaps(xTaskGetCurrentTaskHandle());
+}
+
+static inline void httpd_os_thread_sleep(int msecs)
+{
+    vTaskDelay(msecs / portTICK_PERIOD_MS);
+}
+
+static inline othread_t httpd_os_thread_handle(void)
+{
+    return xTaskGetCurrentTaskHandle();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _OSAL_H_ */

--- a/components/esp_http_server/src/util/ctrl_sock.c
+++ b/components/esp_http_server/src/util/ctrl_sock.c
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "sdkconfig.h"
+#include "esp_log.h"
+#include "ctrl_sock.h"
+
+#if CONFIG_IDF_TARGET_LINUX
+#define IPV4_ENABLED      1
+#define IPV6_ENABLED      1
+#define LOOPBACK_ENABLED  1
+#else   // CONFIG_IDF_TARGET_LINUX
+#define IPV4_ENABLED      CONFIG_LWIP_IPV4
+#define IPV6_ENABLED      CONFIG_LWIP_IPV6
+#define LOOPBACK_ENABLED  CONFIG_LWIP_NETIF_LOOPBACK
+#endif  // !CONFIG_IDF_TARGET_LINUX
+
+/* Control socket, because in some network stacks select can't be woken up any
+ * other way
+ */
+int cs_create_ctrl_sock(int port)
+{
+#if !LOOPBACK_ENABLED
+    ESP_LOGE("esp_http_server", "Please enable LWIP_NETIF_LOOPBACK for %s API", __func__);
+    return -1;
+#endif
+
+    int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd < 0) {
+        return -1;
+    }
+
+    int ret;
+    struct sockaddr_storage addr = {};
+    socklen_t addr_len = 0;
+#if IPV4_ENABLED
+    struct sockaddr_in *addr4 = (struct sockaddr_in *)&addr;
+    addr4->sin_family = AF_INET;
+    addr4->sin_port = htons(port);
+    inet_aton("127.0.0.1", &addr4->sin_addr);
+    addr_len = sizeof(struct sockaddr_in);
+#else
+    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&addr;
+    addr6->sin6_family = AF_INET6;
+    addr6->sin6_port = htons(port);
+    inet6_aton("::1", &addr6->sin6_addr);
+    addr_len = sizeof(struct sockaddr_in6);
+#endif
+    ret = bind(fd, (struct sockaddr *)&addr, addr_len);
+    if (ret < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+void cs_free_ctrl_sock(int fd)
+{
+    close(fd);
+}
+
+int cs_send_to_ctrl_sock(int send_fd, int port, void *data, unsigned int data_len)
+{
+    int ret;
+    struct sockaddr_storage to_addr = {};
+    socklen_t addr_len = 0;
+#if IPV4_ENABLED
+    struct sockaddr_in *addr4 = (struct sockaddr_in *)&to_addr;
+    addr4->sin_family = AF_INET;
+    addr4->sin_port = htons(port);
+    inet_aton("127.0.0.1", &addr4->sin_addr);
+    addr_len = sizeof(struct sockaddr_in);
+#else
+    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&to_addr;
+    addr6->sin6_family = AF_INET6;
+    addr6->sin6_port = htons(port);
+    inet6_aton("::1", &addr6->sin6_addr);
+    addr_len = sizeof(struct sockaddr_in6);
+#endif
+    ret = sendto(send_fd, data, data_len, 0, (struct sockaddr *)&to_addr, addr_len);
+
+    if (ret < 0) {
+        return -1;
+    }
+    return ret;
+}
+
+int cs_recv_from_ctrl_sock(int fd, void *data, unsigned int data_len)
+{
+    int ret;
+    ret = recvfrom(fd, data, data_len, 0, NULL, NULL);
+
+    if (ret < 0) {
+        return -1;
+    }
+    return ret;
+}

--- a/components/esp_http_server/src/util/ctrl_sock.h
+++ b/components/esp_http_server/src/util/ctrl_sock.h
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2018-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * \file ctrl_sock.h
+ * \brief Control Socket for select() wakeup
+ *
+ * LWIP doesn't allow an easy mechanism to on-demand wakeup a thread
+ * sleeping on select. This is a common requirement for sending
+ * control commands to a network server. This control socket API
+ * facilitates the same.
+ */
+#ifndef _CTRL_SOCK_H_
+#define _CTRL_SOCK_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Create a control socket
+ *
+ *      LWIP doesn't allow an easy mechanism to on-demand wakeup a thread
+ *      sleeping on select. This is a common requirement for sending
+ *      control commands to a network server. This control socket API
+ *      facilitates the same.
+ *
+ *      This API will create a UDP control socket on the specified port. It
+ *      will return a socket descriptor that can then be added to your
+ *      fd_set in select()
+ *
+ * @param[in] port the local port on which the control socket will listen
+ *
+ * @return - the socket descriptor that can be added to the fd_set in select.
+ *         - an error code if less than zero
+ */
+int cs_create_ctrl_sock(int port);
+
+/**
+ * @brief Free the control socket
+ *
+ *      This frees up the control socket that was earlier created using
+ *      cs_create_ctrl_sock()
+ *
+ * @param[in] fd the socket descriptor associated with this control socket
+ */
+void cs_free_ctrl_sock(int fd);
+
+/**
+ * @brief Send data to control socket
+ *
+ *      This API sends data to the control socket. If a server is blocked
+ *      on select() with the control socket, this call will wake up that
+ *      server.
+ *
+ * @param[in] send_fd the socket for sending ctrl messages
+ * @param[in] port the port on which the control socket was created
+ * @param[in] data pointer to a buffer that contains data to send on the socket
+ * @param[in] data_len the length of the data contained in the buffer pointed to be data
+ *
+ * @return  - the number of bytes sent to the control socket
+ *          - an error code if less than zero
+ */
+int cs_send_to_ctrl_sock(int send_fd, int port, void *data, unsigned int data_len);
+
+/**
+ * @brief Receive data from control socket
+ *
+ *      This API receives any data that was sent to the control
+ *      socket. This will be typically called from the server thread to
+ *      process any commands on this socket.
+ *
+ * @param[in] fd the socket descriptor of the control socket
+ * @param[in] data pointer to a buffer that will be used to store
+ * received from the control socket
+ * @param[in] data_len the maximum length of the data that can be
+ * stored in the buffer pointed by data
+ *
+ * @return  - the number of bytes received from the control socket
+ *          - an error code if less than zero
+ */
+int cs_recv_from_ctrl_sock(int fd, void *data, unsigned int data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ! _CTRL_SOCK_H_ */

--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -695,6 +695,17 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
             // Arm Web / WebDAV Server (real httpd starts on first request)
             httpServer.startOnDemand();
 
+            // Give the interface an IPv6 link-local address BEFORE mDNS starts.
+            // Resolvers (macOS getaddrinfo, and so Finder) query A and AAAA
+            // together and wait for both. With no IPv6 address the responder
+            // answered neither the AAAA nor a negative NSEC record, so every
+            // lookup of <name>.local sat out the resolver's full 5-second
+            // timeout. Finder opens a fresh connection per request, so one file
+            // copy paid that 5s ~200 times -- slow enough that its client gave
+            // up mid-PUT and the file was left at the zero length its
+            // placeholder PUT created.
+            esp_netif_create_ip6_linklocal(pFnWiFi->_wifi_sta);
+
             // Start mDNS Service
             mdns_init();
             mdns_hostname_set(Config.get_general_devicename().c_str());

--- a/lib/www/webdav/handler.cpp
+++ b/lib/www/webdav/handler.cpp
@@ -29,6 +29,15 @@
 
 #include <cstring>
 
+// A non-ESP_OK return makes esp_http_server close the socket, which is required
+// whenever the request body was not read to its end: with a chunked body there
+// is no Content-Length for the server to skip by, so the leftover bytes would
+// be parsed as the start of the next request. See Request::connectionReusable.
+static esp_err_t finish(WebDav::Request &req)
+{
+    return req.connectionReusable() ? ESP_OK : ESP_FAIL;
+}
+
 esp_err_t webdav_handler(httpd_req_t *httpd_req)
 {
     WebDav::Server *server = (WebDav::Server *)httpd_req->user_ctx;
@@ -59,7 +68,7 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     case HTTP_GET:
         ret = server->doGet(req, resp);
         if ( ret == 200 )
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_HEAD:
         ret = server->doHead(req, resp);
@@ -67,7 +76,7 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     case HTTP_LOCK:
         ret = server->doLock(req, resp);
         if ( ret == 200 )
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_MKCOL:
         ret = server->doMkcol(req, resp);
@@ -81,12 +90,12 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     case HTTP_PROPFIND:
         ret = server->doPropfind(req, resp);
         if (ret == 207)
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_PROPPATCH:
         ret = server->doProppatch(req, resp);
         if (ret == 207)
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_PUT:
         ret = server->doPut(req, resp);
@@ -132,7 +141,7 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
         resp.closeBody();
     }
 
-    return ESP_OK;
+    return finish(req);
 }
 
 void webdav_register(httpd_handle_t server, const char *root_uri, const char *root_path)

--- a/lib/www/webdav/request.cpp
+++ b/lib/www/webdav/request.cpp
@@ -18,7 +18,15 @@
 #include "request.h"
 
 #include <esp_http_server.h>
+#include <cctype>
 #include <string>
+
+// Not in esp_http_server.h, but a plain (non-static) function of the
+// esp_http_server component: like the recv() behind httpd_req_recv, but
+// without the Content-Length cap (remaining_len), and it drains the parser's
+// pending buffer first -- both required to read a chunked body, where
+// content_len is 0 and the first body bytes may already sit in that buffer.
+extern "C" int httpd_recv(httpd_req_t *r, char *buf, size_t buf_len);
 
 using namespace WebDav;
 
@@ -44,6 +52,172 @@ bool Request::parseRequest() {
     }
 
     return true;
+}
+
+bool Request::isChunked() {
+    if (!chunkedKnown) {
+        std::string te = getHeader("Transfer-Encoding");
+        for (auto &c : te)
+            c = tolower((unsigned char)c);
+        chunkedFlag = te.find("chunked") != std::string::npos;
+        chunkedKnown = true;
+    }
+    return chunkedFlag;
+}
+
+// A client that sent "Expect: 100-continue" holds the body back until we
+// answer; esp_http_server never does, so we must (macOS Finder stalls its
+// PUT body without this).
+void Request::handleExpect() {
+    if (continueSent)
+        return;
+    if (getHeader("Expect").empty())
+        return;
+    sendContinue();
+    continueSent = true;
+}
+
+// A recv timeout is NOT an error -- it only means the next TCP segment has not
+// arrived yet, and the client may still be mid-body. macOS webdavfs routinely
+// sends a chunk's data and the CRLF that terminates it in separate segments,
+// with a gap longer than the socket's recv_wait_timeout; treating that timeout
+// as fatal threw away a fully-received body and answered 500, leaving the
+// zero-length file the placeholder PUT had created. Retry a bounded number of
+// times (the Content-Length path has always retried this way) and only fail on
+// a real socket error or a close.
+int Request::recvRaw(char *buf, size_t len) {
+    for (int tries = 0; tries < RECV_TIMEOUT_RETRIES; ++tries) {
+        int r = httpd_recv(req, buf, len);
+        if (r != HTTPD_SOCK_ERR_TIMEOUT)
+            return r;   // data, peer close (0), or a genuine error
+    }
+
+    Debug_printv("recv timed out %d times, giving up len[%d]",
+                 RECV_TIMEOUT_RETRIES, (int)len);
+    return -1;
+}
+
+bool Request::recvByte(char *c) {
+    return recvRaw(c, 1) == 1;
+}
+
+// Read one CRLF-terminated framing line (chunk-size line or trailer) into
+// line[], NUL-terminated, CR/LF stripped. False on socket error, a stray CR,
+// or an overlong line.
+bool Request::readChunkLine(char *line, size_t cap) {
+    size_t n = 0;
+    for (;;) {
+        char c;
+        if (!recvByte(&c))
+            return false;
+        if (c == '\r') {
+            if (!recvByte(&c) || c != '\n')
+                return false;
+            break;
+        }
+        if (c == '\n')      // tolerate bare LF
+            break;
+        if (n + 1 >= cap)
+            return false;
+        line[n++] = c;
+    }
+    line[n] = 0;
+    return true;
+}
+
+int Request::readBodyChunked(char *buf, int len) {
+    if (broken)
+        return -1;
+    if (chunksDone || len <= 0)
+        return 0;
+
+    if (chunkLeft == 0) {
+        // chunk-size line: hex digits, then optional ";ext" up to CRLF
+        char line[128];
+        if (!readChunkLine(line, sizeof(line))) {
+            Debug_printv("bad chunk-size line");
+            return chunkFail();
+        }
+        size_t size = 0;
+        int i = 0;
+        bool any = false;
+        for (; line[i]; ++i) {
+            char c = line[i];
+            unsigned d;
+            if (c >= '0' && c <= '9')      d = c - '0';
+            else if (c >= 'a' && c <= 'f') d = c - 'a' + 10;
+            else if (c >= 'A' && c <= 'F') d = c - 'A' + 10;
+            else break;
+            if (size > 0x0FFFFFFF)         // absurd chunk size: bail out
+                return chunkFail();
+            size = (size << 4) | d;
+            any = true;
+        }
+        if (!any)
+            return chunkFail();
+        if (line[i] && line[i] != ';' && line[i] != ' ' && line[i] != '\t')
+            return chunkFail();
+        if (size == 0) {
+            // trailer section: header lines until an empty line
+            for (;;) {
+                if (!readChunkLine(line, sizeof(line)))
+                    return chunkFail();
+                if (!line[0])
+                    break;
+            }
+            chunksDone = true;
+            return 0;
+        }
+        chunkLeft = size;
+    }
+
+    int want = (size_t)len < chunkLeft ? len : (int)chunkLeft;
+    int r = recvRaw(buf, want);
+    if (r <= 0)
+        return chunkFail();
+    chunkLeft -= r;
+    bodyDone += r;
+
+    if (chunkLeft == 0) {
+        // Stop here if the client told us the body length and we now have it.
+        // macOS webdavfs holds back the CRLF + 0-chunk that close the body
+        // until it has seen a response, so reading on would deadlock: it waits
+        // for our reply, we wait for its framing. The bytes we leave unread
+        // desync the connection, so it must not be reused -- see
+        // connectionReusable().
+        size_t expected = expectedEntityLength();
+        if (expected > 0 && bodyDone >= expected) {
+            chunksDone = true;
+            unterminated = true;
+            return r;
+        }
+
+        // consume the CRLF that closes the chunk data
+        char c;
+        if (!recvByte(&c))
+            return chunkFail();
+        if (c == '\r' && !recvByte(&c))
+            return chunkFail();
+        if (c != '\n')
+            return chunkFail();
+    }
+    return r;
+}
+
+size_t Request::expectedEntityLength() {
+    if (!expectedKnown) {
+        std::string v = getHeader("X-Expected-Entity-Length");
+        expectedLen = 0;
+        for (size_t i = 0; i < v.size(); ++i) {
+            if (v[i] < '0' || v[i] > '9') {
+                expectedLen = 0;        // not a plain number: ignore it
+                break;
+            }
+            expectedLen = expectedLen * 10 + (v[i] - '0');
+        }
+        expectedKnown = true;
+    }
+    return expectedLen;
 }
 
 std::string Request::getDestination() {

--- a/lib/www/webdav/request.h
+++ b/lib/www/webdav/request.h
@@ -25,6 +25,12 @@
 
 #define HTTPD_100      "100 Continue"
 
+// How many consecutive socket recv timeouts to ride out before declaring the
+// body lost. The socket's recv_wait_timeout is the unit, so this bounds the
+// wait for a client that has gone quiet mid-body without hanging the (single-
+// threaded) server on one that has died. See Request::recvRaw.
+#define RECV_TIMEOUT_RETRIES 6
+
 namespace WebDav
 {
 
@@ -52,6 +58,31 @@ namespace WebDav
 
         bool parseRequest();
         std::string getDestination();
+
+        // Chunked transfer encoding (macOS Finder PUTs bodies this way; the
+        // esp_http_server can't dechunk, so we do). readBodyChunked() returns
+        // >0 data bytes, 0 at end-of-body (final chunk + trailers consumed),
+        // <0 on a socket/protocol error. After an error or an undrained
+        // chunked body the connection byte stream is desynchronized --
+        // connectionReusable() then says the handler must close the socket.
+        bool isChunked();
+        int readBodyChunked(char *buf, int len);
+        void handleExpect();
+
+        // macOS webdavfs (Finder) sends the whole body and then sits on the
+        // CRLF + 0-chunk that terminate it until it has seen a response -- a
+        // deadlock, since we are waiting for exactly those bytes. It hands us
+        // the body length up front in X-Expected-Entity-Length instead, which
+        // is what that header is for. 0 when absent.
+        size_t expectedEntityLength();
+
+        bool connectionReusable()
+        {
+            // unterminated: we stopped on the expected length without reading
+            // the trailing framing, so the byte stream is out of step and the
+            // socket must not be reused for another request.
+            return !broken && !unterminated && (!isChunked() || chunksDone);
+        }
 
         std::string getPath() { return path; }
         enum Depth getDepth() { return depth; }
@@ -85,18 +116,47 @@ namespace WebDav
             return req->content_len;
         }
 
+        // Same timeout rule as recvRaw: a quiet moment mid-body is not the end
+        // of the body. Retrying here rather than returning 0 matters because
+        // doPut's Content-Length loop treats any <= 0 as end-of-stream and then
+        // reports the short body as an error.
         int readBody(char *buf, int len)
         {
-            int ret = httpd_req_recv(req, buf, len);
-            if (ret == HTTPD_SOCK_ERR_TIMEOUT)
-                /* Retry receiving if timeout occurred */
-                return 0;
+            for (int tries = 0; tries < RECV_TIMEOUT_RETRIES; ++tries)
+            {
+                int ret = httpd_req_recv(req, buf, len);
+                if (ret != HTTPD_SOCK_ERR_TIMEOUT)
+                    return ret;
+            }
 
-            return ret;
+            Debug_printv("recv timed out %d times, giving up len[%d]",
+                         RECV_TIMEOUT_RETRIES, len);
+            return -1;
         }
 
     private:
         httpd_req_t *req;
+
+        // chunked-decoder state
+        bool chunkedKnown = false;
+        bool chunkedFlag = false;
+        size_t chunkLeft = 0;       // data bytes left in the current chunk
+        bool chunksDone = false;    // body complete
+        bool broken = false;        // socket/protocol error mid-body
+        bool continueSent = false;  // "100 Continue" already sent
+        bool unterminated = false;  // stopped on the expected length, framing unread
+        size_t bodyDone = 0;        // data bytes delivered so far
+        bool expectedKnown = false;
+        size_t expectedLen = 0;
+
+        int recvRaw(char *buf, size_t len);
+        bool recvByte(char *c);
+        bool readChunkLine(char *line, size_t cap);
+        int chunkFail()
+        {
+            broken = true;
+            return -1;
+        }
 
     protected:
         std::string path;

--- a/lib/www/webdav/webdav_server.cpp
+++ b/lib/www/webdav/webdav_server.cpp
@@ -203,11 +203,21 @@ static int mfile_copy_recursive(const std::string &source, const std::string &de
 
 static void discardRequestBody(Request &req)
 {
+    char buffer[512];
+
+    if (req.isChunked())
+    {
+        req.handleExpect();
+        while (req.readBodyChunked(buffer, sizeof(buffer)) > 0)
+            ;
+        return;
+    }
+
     int remaining = req.getContentLength();
     if (remaining <= 0)
         return;
 
-    char buffer[512];
+    req.handleExpect();
     while (remaining > 0)
     {
         int r = req.readBody(buffer, std::min(remaining, static_cast<int>(sizeof(buffer))));
@@ -993,9 +1003,9 @@ int Server::doPut(Request &req, Response &resp)
     if (!stream || !stream->isOpen())
         return 404;
 
-    int remaining = req.getContentLength();
-
     // 16 KB: fewer read/write iterations per PUT; buffer lives in PSRAM.
+    // (The Content-Length case declares its own `remaining` below; the chunked
+    // case has no Content-Length to work from.)
     const int chunkSize = 16384;
     uint8_t *chunk = (uint8_t *)malloc(chunkSize);
     if (!chunk) {
@@ -1005,19 +1015,47 @@ int Server::doPut(Request &req, Response &resp)
 
     int ret = 0;
 
-    while (remaining > 0)
-    {
-        int r = req.readBody((char *)chunk, std::min(remaining, chunkSize));
-        if (r <= 0)
-            break;
+    req.handleExpect();
 
-        if ((int)stream->write(chunk, r) != r)
+    if (req.isChunked())
+    {
+        // Transfer-Encoding: chunked (macOS Finder) -- no Content-Length;
+        // the decoder returns 0 at end-of-body, <0 on error. On error the
+        // connection is desynchronized; webdav_handler closes it.
+        for (;;)
         {
-            ret = -1;
-            break;
+            int r = req.readBodyChunked((char *)chunk, chunkSize);
+            if (r == 0)
+                break;
+            if (r < 0 || (int)stream->write(chunk, r) != r)
+            {
+                ret = -1;
+                break;
+            }
+        }
+    }
+    else
+    {
+        int remaining = req.getContentLength();
+
+        while (remaining > 0)
+        {
+            int r = req.readBody((char *)chunk, std::min(remaining, chunkSize));
+            if (r <= 0)
+                break;
+
+            if ((int)stream->write(chunk, r) != r)
+            {
+                ret = -1;
+                break;
+            }
+
+            remaining -= r;
         }
 
-        remaining -= r;
+        if (remaining > 0 && ret == 0)
+            ret = -1;   // truncated body (recv timeout): report it, don't
+                        // return 201 for a short file
     }
 
     free(chunk);


### PR DESCRIPTION
> **Alternative available:** #55 implements the same fixes without vendoring `esp_http_server` (uses a recv-override tee instead). Same behaviour; pick one.

Fixes #53
Fixes #52

Copying a file to the Meatloaf from macOS Finder took ~55s and left a **zero-byte file**. Two independent bugs; both are needed.

## 1. Every `.local` lookup stalled 5 seconds (`lib/hardware/fnWiFi.cpp`)

Resolvers query A and AAAA together and wait for both. `mdns_init()` ran on an interface with **no IPv6 address**, so the responder answered neither the AAAA query nor a negative NSEC record — the resolver sat out its full timeout every time.

```
A    query -> 192.168.1.149   in 2 ms
AAAA query -> No Such Record  after 5.000 s
```

Measured from macOS: **5.010s -> 0.006s** per lookup. Finder opens ~200 connections for one file copy and paid it on each — slow enough that its client abandons requests mid-body. Fixed by creating the link-local IPv6 address before mDNS starts. This speeds up *everything* the device serves, not just WebDAV.

## 2. Chunked request bodies were dropped (`lib/www/webdav/`, `components/esp_http_server/`)

Finder PUTs with `Transfer-Encoding: chunked` and no `Content-Length`. `doPut` looped on `getContentLength()` — zero — wrote nothing, and answered `201`. Hence the empty file.

Three parts:

- **`esp_http_server` can't hand a chunked body to a handler.** `http_parser` de-chunks it itself and eats the first chunk-size line before `cb_on_body` can pause, so the pushed-back data starts mid-chunk and the framing is unrecoverable. Vendored the component and paused at end-of-headers instead, leaving the raw body for the handler to de-chunk.
- **A recv timeout was treated as fatal.** It only means the next TCP segment hasn't arrived. The reader discarded a fully-received body and returned 500. Now rides out a bounded number of timeouts, as the Content-Length path already did. `readBody` had the same latent bug (returned `0`, which `doPut` reads as end-of-stream — a slow client would be written short, then reported as an error).
- **Finder withholds the chunk terminator until it sees a response.** Verified on the wire:

```
189.038  client --> 619 B   headers + "15B\r\n" + all 347 data bytes
219.278  server <-- 500     (after waiting for the terminator)
220.332  client -->   7 B   "\r\n0\r\n\r\n"  <- released only AFTER we gave up
```

  Waiting for those bytes is a deadlock. Finder sends the body length up front in `X-Expected-Entity-Length` — which is what that header is for — so the body is complete once that many bytes arrive. The trailing framing then goes unread, so the connection is marked non-reusable and the socket is closed rather than reused for a request that would parse garbage.

## Verified on ESP32-S3 hardware

347 B, 3 KB, 4 KB and 20 KB all land byte-exact with the terminator withheld, in ~0.2s each — previously each hung 30s and returned 500 with a zero-length file. A real Finder copy of a 3178-byte file now completes near-instantly with correct content.

Not addressed: two *concurrent* chunked PUTs stalled during debugging. That was very likely the 5s-lookup starvation and Finder copies work now, but I haven't proven it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)