### PR TITLE
Fix WebDAV writes from macOS Finder — recv-override variant (no esp_http_server fork)

### DIFF
--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -695,6 +695,17 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
             // Arm Web / WebDAV Server (real httpd starts on first request)
             httpServer.startOnDemand();
 
+            // Give the interface an IPv6 link-local address BEFORE mDNS starts.
+            // Resolvers (macOS getaddrinfo, and so Finder) query A and AAAA
+            // together and wait for both. With no IPv6 address the responder
+            // answered neither the AAAA nor a negative NSEC record, so every
+            // lookup of <name>.local sat out the resolver's full 5-second
+            // timeout. Finder opens a fresh connection per request, so one file
+            // copy paid that 5s ~200 times -- slow enough that its client gave
+            // up mid-PUT and the file was left at the zero length its
+            // placeholder PUT created.
+            esp_netif_create_ip6_linklocal(pFnWiFi->_wifi_sta);
+
             // Start mDNS Service
             mdns_init();
             mdns_hostname_set(Config.get_general_devicename().c_str());

--- a/lib/www/web_server.cpp
+++ b/lib/www/web_server.cpp
@@ -31,6 +31,7 @@
 #include "proxy/proxy.h"
 #include "template/template.h"
 #include "webdav/handler.h"
+#include "webdav/body_capture.h"
 #include "ws/ws.h"
 
 #include <freertos/FreeRTOS.h>
@@ -158,6 +159,12 @@ static esp_err_t httpd_open_fn(httpd_handle_t hd, int sockfd)
     setsockopt(sockfd, SOL_SOCKET, SO_LINGER, &so_linger, sizeof(so_linger));
     int nodelay = 1;
     setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+
+    // Install the WebDAV raw-body capture (a session recv override) so the
+    // WebDAV handler can read chunked request bodies that esp_http_server
+    // cannot deliver. Bounded and reset per request; harmless on other
+    // connections (see body_capture.h).
+    WebDav::body_capture_install(hd, sockfd);
     return ESP_OK;
 }
 

--- a/lib/www/webdav/body_capture.cpp
+++ b/lib/www/webdav/body_capture.cpp
@@ -1,0 +1,145 @@
+// Meatloaf - A Commodore 64/128 multi-device emulator
+// https://github.com/idolpx/meatloaf
+// Copyright(C) 2020 James Johnston
+//
+// Meatloaf is free software : you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Meatloaf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Meatloaf. If not, see <http://www.gnu.org/licenses/>.
+
+#include "body_capture.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <esp_heap_caps.h>
+
+#include "../../include/debug.h"
+
+// The real socket read behind the session recv function. Declared in the
+// component's private header (esp_httpd_priv.h), but a plain exported symbol --
+// the same access the WebDAV code already relies on for httpd_recv(). Wrapping
+// it (rather than calling recv() directly) keeps the component's timeout and
+// control-socket semantics intact.
+extern "C" int httpd_default_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
+
+namespace WebDav
+{
+    namespace
+    {
+        struct BodyCapture
+        {
+            char  *buf;
+            size_t cap;
+            size_t len;
+            bool   overflow;       // grew past cap: buffer no longer complete
+            bool   reset_pending;  // clear on the next byte (new request)
+        };
+
+        void *cap_malloc(size_t n)
+        {
+            void *p = heap_caps_malloc(n, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+            return p ? p : malloc(n);   // fall back to internal RAM
+        }
+
+        void body_capture_free(void *ctx)
+        {
+            BodyCapture *cap = (BodyCapture *)ctx;
+            if (!cap)
+                return;
+            free(cap->buf);
+            free(cap);
+        }
+
+        // Session recv override: read as the stock server would, then tee the
+        // bytes into the capture buffer.
+        int body_capture_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags)
+        {
+            BodyCapture *cap = (BodyCapture *)httpd_sess_get_transport_ctx(hd, sockfd);
+            int r = httpd_default_recv(hd, sockfd, buf, buf_len, flags);
+            if (cap && r > 0)
+            {
+                if (cap->reset_pending)
+                {
+                    cap->len = 0;
+                    cap->overflow = false;
+                    cap->reset_pending = false;
+                }
+                if (!cap->overflow)
+                {
+                    if (cap->len + (size_t)r <= cap->cap)
+                    {
+                        memcpy(cap->buf + cap->len, buf, (size_t)r);
+                        cap->len += (size_t)r;
+                    }
+                    else
+                    {
+                        cap->overflow = true;
+                    }
+                }
+            }
+            return r;
+        }
+    } // namespace
+
+    void body_capture_install(httpd_handle_t hd, int sockfd)
+    {
+        BodyCapture *cap = (BodyCapture *)cap_malloc(sizeof(BodyCapture));
+        if (!cap)
+            return;
+        cap->buf = (char *)cap_malloc(BODY_CAPTURE_CAP);
+        if (!cap->buf)
+        {
+            free(cap);
+            return;
+        }
+        cap->cap = BODY_CAPTURE_CAP;
+        cap->len = 0;
+        cap->overflow = false;
+        cap->reset_pending = false;
+
+        httpd_sess_set_transport_ctx(hd, sockfd, cap, body_capture_free);
+        httpd_sess_set_recv_override(hd, sockfd, body_capture_recv);
+    }
+
+    void body_capture_reset(httpd_req_t *req)
+    {
+        if (!req)
+            return;
+        BodyCapture *cap = (BodyCapture *)httpd_sess_get_transport_ctx(req->handle,
+                                                                       httpd_req_to_sockfd(req));
+        if (cap)
+            cap->reset_pending = true;
+    }
+
+    bool body_capture_get(httpd_req_t *req, const char **body, size_t *body_len)
+    {
+        if (!req)
+            return false;
+        BodyCapture *cap = (BodyCapture *)httpd_sess_get_transport_ctx(req->handle,
+                                                                       httpd_req_to_sockfd(req));
+        if (!cap || cap->overflow)
+            return false;
+
+        // Locate the CRLFCRLF that ends the headers; the body follows it.
+        for (size_t i = 3; i < cap->len; ++i)
+        {
+            if (cap->buf[i - 3] == '\r' && cap->buf[i - 2] == '\n' &&
+                cap->buf[i - 1] == '\r' && cap->buf[i] == '\n')
+            {
+                *body = cap->buf + i + 1;
+                *body_len = cap->len - (i + 1);
+                return true;
+            }
+        }
+        return false;
+    }
+
+} // namespace WebDav

--- a/lib/www/webdav/body_capture.h
+++ b/lib/www/webdav/body_capture.h
@@ -1,0 +1,70 @@
+// Meatloaf - A Commodore 64/128 multi-device emulator
+// https://github.com/idolpx/meatloaf
+// Copyright(C) 2020 James Johnston
+//
+// Meatloaf is free software : you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Meatloaf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Meatloaf. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <esp_http_server.h>
+#include <cstddef>
+
+// Per-connection raw request capture ("tee") for reading chunked request bodies
+// without forking esp_http_server.
+//
+// esp_http_server cannot hand a Transfer-Encoding: chunked request body to a
+// URI handler: http_parser de-chunks the body itself and consumes the first
+// chunk-size line before the handler runs, so by handler time the raw framing
+// is gone and content_len is 0. The documented workaround is to override the
+// session recv function (httpd_sess_set_recv_override, a public API) and read
+// the raw stream yourself.
+//
+// This installs such an override at connection open: it copies every byte the
+// parser reads off the socket into a small per-session buffer. The WebDAV
+// handler then locates the request body inside that buffer (the bytes after the
+// CRLFCRLF that ends the headers) and de-chunks straight from it, falling
+// through to the socket for whatever had not been read yet. See
+// WebDav::Request::readBodyChunked.
+//
+// The buffer is bounded and reset per request; on overflow it stops copying, so
+// a large POST or a websocket stream on the same server never makes it grow.
+// Only small WebDAV request bodies (Finder PUTs) rely on it, and they fit well
+// inside the cap.
+
+namespace WebDav
+{
+    // Cap on the captured prefix. Must exceed the largest request head plus the
+    // leading body bytes the parser reads in the same block -- a few hundred
+    // bytes in practice. 4 KB is comfortable and bounds per-connection memory.
+    static const size_t BODY_CAPTURE_CAP = 4096;
+
+    // Install the recv override + capture context on a freshly opened
+    // connection. Call from the server's open_fn. A no-op on allocation
+    // failure -- the connection then behaves exactly as the stock server would
+    // (a chunked PUT would still write nothing, but nothing crashes).
+    void body_capture_install(httpd_handle_t hd, int sockfd);
+
+    // Flag the current request's capture as consumed so the next request on a
+    // kept-alive connection starts fresh. Call once per request (all methods).
+    void body_capture_reset(httpd_req_t *req);
+
+    // Hand back the captured raw request body for this request: the bytes after
+    // the end-of-headers marker. Returns false when there is no capture
+    // context, the CRLFCRLF was not found, or the capture overflowed -- in all
+    // of which the caller must not trust the buffer. *body points into the live
+    // capture buffer (valid until the connection closes); *body_len is its
+    // length.
+    bool body_capture_get(httpd_req_t *req, const char **body, size_t *body_len);
+
+} // namespace WebDav

--- a/lib/www/webdav/handler.cpp
+++ b/lib/www/webdav/handler.cpp
@@ -26,8 +26,19 @@
 #include "webdav_server.h"
 #include "request.h"
 #include "response.h"
+#include "body_capture.h"
 
 #include <cstring>
+
+// A non-ESP_OK return makes esp_http_server close the socket, required when the
+// request body was not read to its end: a chunked body has no Content-Length
+// for the server to skip by, so the leftover bytes would be parsed as the next
+// request. connectionReusable() is false in exactly that case (an unterminated
+// or errored chunked body).
+static esp_err_t finish(WebDav::Request &req)
+{
+    return req.connectionReusable() ? ESP_OK : ESP_FAIL;
+}
 
 esp_err_t webdav_handler(httpd_req_t *httpd_req)
 {
@@ -35,6 +46,14 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     WebDav::Request req(httpd_req);
     WebDav::Response resp(httpd_req);
     int ret;
+
+    // Mark this request's captured body prefix consumed on every exit path, so
+    // the next request on a kept-alive connection starts with a fresh buffer.
+    struct CaptureReset
+    {
+        httpd_req_t *r;
+        ~CaptureReset() { WebDav::body_capture_reset(r); }
+    } captureReset{httpd_req};
 
     Debug_printv("uri[%s]", httpd_req->uri);
 
@@ -59,7 +78,7 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     case HTTP_GET:
         ret = server->doGet(req, resp);
         if ( ret == 200 )
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_HEAD:
         ret = server->doHead(req, resp);
@@ -67,7 +86,7 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     case HTTP_LOCK:
         ret = server->doLock(req, resp);
         if ( ret == 200 )
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_MKCOL:
         ret = server->doMkcol(req, resp);
@@ -81,12 +100,12 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
     case HTTP_PROPFIND:
         ret = server->doPropfind(req, resp);
         if (ret == 207)
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_PROPPATCH:
         ret = server->doProppatch(req, resp);
         if (ret == 207)
-            return ESP_OK;
+            return finish(req);
         break;
     case HTTP_PUT:
         ret = server->doPut(req, resp);
@@ -132,7 +151,7 @@ esp_err_t webdav_handler(httpd_req_t *httpd_req)
         resp.closeBody();
     }
 
-    return ESP_OK;
+    return finish(req);
 }
 
 void webdav_register(httpd_handle_t server, const char *root_uri, const char *root_path)

--- a/lib/www/webdav/request.cpp
+++ b/lib/www/webdav/request.cpp
@@ -16,9 +16,15 @@
 // along with Meatloaf. If not, see <http://www.gnu.org/licenses/>.
 
 #include "request.h"
+#include "body_capture.h"
 
 #include <esp_http_server.h>
+#include <cctype>
+#include <cstring>
 #include <string>
+
+// Real socket read behind the session recv function (see body_capture.cpp).
+extern "C" int httpd_default_recv(httpd_handle_t hd, int sockfd, char *buf, size_t buf_len, int flags);
 
 using namespace WebDav;
 
@@ -58,4 +64,194 @@ std::string Request::getDestination() {
         return "";
 
     return destination.substr(pos + host.length());
+}
+
+bool Request::isChunked() {
+    if (!chunkedKnown) {
+        std::string te = getHeader("Transfer-Encoding");
+        for (auto &c : te)
+            c = tolower((unsigned char)c);
+        chunkedFlag = te.find("chunked") != std::string::npos;
+        chunkedKnown = true;
+    }
+    return chunkedFlag;
+}
+
+size_t Request::expectedEntityLength() {
+    if (!expectedKnown) {
+        std::string v = getHeader("X-Expected-Entity-Length");
+        expectedLen = 0;
+        for (size_t i = 0; i < v.size(); ++i) {
+            if (v[i] < '0' || v[i] > '9') {
+                expectedLen = 0;        // not a plain number: ignore it
+                break;
+            }
+            expectedLen = expectedLen * 10 + (v[i] - '0');
+        }
+        expectedKnown = true;
+    }
+    return expectedLen;
+}
+
+// A client that sent "Expect: 100-continue" holds the body back until we
+// answer; esp_http_server never does, so we must (macOS Finder stalls its PUT
+// body without this).
+void Request::handleExpect() {
+    if (continueSent)
+        return;
+    if (getHeader("Expect").empty())
+        return;
+    sendContinue();
+    continueSent = true;
+}
+
+// Point the raw-body reader at the prefix the session recv override captured:
+// everything after the request's CRLFCRLF. Anything past this prefix is read
+// straight from the socket by recvRaw. Failure here means the prefix was
+// unavailable (no capture ctx / overflow / header terminator not found), so a
+// chunked body cannot be reconstructed and the read is failed rather than
+// silently truncated.
+void Request::initCapture() {
+    capInit = true;
+    if (!body_capture_get(req, &capBuf, &capEnd)) {
+        captureFailed = true;
+        capBuf = nullptr;
+        capEnd = 0;
+    }
+    capPos = 0;
+}
+
+// Raw body bytes: first drain the captured prefix, then read the socket for the
+// remainder. httpd_default_recv reads the socket directly (not the parser's
+// pending buffer), and the prefix already holds every byte the parser took off
+// the socket, so the two sources never overlap.
+int Request::recvRaw(char *buf, size_t len) {
+    if (!capInit)
+        initCapture();
+
+    if (capPos < capEnd) {
+        size_t n = capEnd - capPos;
+        if (n > len)
+            n = len;
+        memcpy(buf, capBuf + capPos, n);
+        capPos += n;
+        return (int)n;
+    }
+
+    if (captureFailed)
+        return -1;      // no reliable prefix: cannot continue the chunked body
+
+    for (int tries = 0; tries < RECV_TIMEOUT_RETRIES; ++tries) {
+        int r = httpd_default_recv(req->handle, httpd_req_to_sockfd(req), buf, len, 0);
+        if (r != HTTPD_SOCK_ERR_TIMEOUT)
+            return r;   // data, peer close (0), or a genuine error
+    }
+    Debug_printv("recv timed out %d times, giving up len[%d]", RECV_TIMEOUT_RETRIES, (int)len);
+    return -1;
+}
+
+bool Request::recvByte(char *c) {
+    return recvRaw(c, 1) == 1;
+}
+
+// Read one CRLF-terminated framing line (chunk-size line or trailer) into
+// line[], NUL-terminated, CR/LF stripped. False on socket error, a stray CR,
+// or an overlong line.
+bool Request::readChunkLine(char *line, size_t cap) {
+    size_t n = 0;
+    for (;;) {
+        char c;
+        if (!recvByte(&c))
+            return false;
+        if (c == '\r') {
+            if (!recvByte(&c) || c != '\n')
+                return false;
+            break;
+        }
+        if (c == '\n')      // tolerate bare LF
+            break;
+        if (n + 1 >= cap)
+            return false;
+        line[n++] = c;
+    }
+    line[n] = 0;
+    return true;
+}
+
+int Request::readBodyChunked(char *buf, int len) {
+    if (broken)
+        return -1;
+    if (chunksDone || len <= 0)
+        return 0;
+
+    if (chunkLeft == 0) {
+        // chunk-size line: hex digits, then optional ";ext" up to CRLF
+        char line[128];
+        if (!readChunkLine(line, sizeof(line))) {
+            Debug_printv("bad chunk-size line");
+            return chunkFail();
+        }
+        size_t size = 0;
+        int i = 0;
+        bool any = false;
+        for (; line[i]; ++i) {
+            char c = line[i];
+            unsigned d;
+            if (c >= '0' && c <= '9')      d = c - '0';
+            else if (c >= 'a' && c <= 'f') d = c - 'a' + 10;
+            else if (c >= 'A' && c <= 'F') d = c - 'A' + 10;
+            else break;
+            if (size > 0x0FFFFFFF)         // absurd chunk size: bail out
+                return chunkFail();
+            size = (size << 4) | d;
+            any = true;
+        }
+        if (!any)
+            return chunkFail();
+        if (line[i] && line[i] != ';' && line[i] != ' ' && line[i] != '\t')
+            return chunkFail();
+        if (size == 0) {
+            // trailer section: header lines until an empty line
+            for (;;) {
+                if (!readChunkLine(line, sizeof(line)))
+                    return chunkFail();
+                if (!line[0])
+                    break;
+            }
+            chunksDone = true;
+            return 0;
+        }
+        chunkLeft = size;
+    }
+
+    int want = (size_t)len < chunkLeft ? len : (int)chunkLeft;
+    int r = recvRaw(buf, want);
+    if (r <= 0)
+        return chunkFail();
+    chunkLeft -= r;
+    bodyDone += r;
+
+    if (chunkLeft == 0) {
+        // Stop here if the client told us the body length and we now have it.
+        // macOS webdavfs holds back the CRLF + 0-chunk that close the body until
+        // it has seen a response, so reading on would deadlock: it waits for our
+        // reply, we wait for its framing. The bytes we leave unread desync the
+        // connection, so it must not be reused -- see connectionReusable().
+        size_t expected = expectedEntityLength();
+        if (expected > 0 && bodyDone >= expected) {
+            chunksDone = true;
+            unterminated = true;
+            return r;
+        }
+
+        // consume the CRLF that closes the chunk data
+        char c;
+        if (!recvByte(&c))
+            return chunkFail();
+        if (c == '\r' && !recvByte(&c))
+            return chunkFail();
+        if (c != '\n')
+            return chunkFail();
+    }
+    return r;
 }

--- a/lib/www/webdav/request.h
+++ b/lib/www/webdav/request.h
@@ -25,6 +25,12 @@
 
 #define HTTPD_100      "100 Continue"
 
+// How many consecutive socket recv timeouts to ride out before declaring the
+// body lost. The socket's recv_wait_timeout is the unit, so this bounds the
+// wait for a client that went quiet mid-body without hanging the (single-
+// threaded) server on one that has died. See Request::recvRaw.
+#define RECV_TIMEOUT_RETRIES 6
+
 namespace WebDav
 {
 
@@ -52,6 +58,32 @@ namespace WebDav
 
         bool parseRequest();
         std::string getDestination();
+
+        // Chunked transfer encoding (macOS Finder PUTs bodies this way; the
+        // esp_http_server can't dechunk, so we read the raw body captured by
+        // the session recv override -- see body_capture.h -- and dechunk it
+        // ourselves). readBodyChunked() returns >0 data bytes, 0 at
+        // end-of-body, <0 on a socket/protocol error. After an error or an
+        // undrained chunked body the connection byte stream is desynchronized;
+        // connectionReusable() then says the handler must close the socket.
+        bool isChunked();
+        int readBodyChunked(char *buf, int len);
+        void handleExpect();
+
+        // macOS webdavfs (Finder) sends the whole body and then holds back the
+        // CRLF + 0-chunk that terminate it until it has seen a response -- a
+        // deadlock, since we are waiting for exactly those bytes. It gives us
+        // the body length up front in X-Expected-Entity-Length, which is what
+        // that header is for. 0 when absent.
+        size_t expectedEntityLength();
+
+        bool connectionReusable()
+        {
+            // unterminated: we stopped on the expected length without reading
+            // the trailing framing, so the byte stream is out of step and the
+            // socket must not be reused for another request.
+            return !broken && !unterminated && (!isChunked() || chunksDone);
+        }
 
         std::string getPath() { return path; }
         enum Depth getDepth() { return depth; }
@@ -85,18 +117,58 @@ namespace WebDav
             return req->content_len;
         }
 
+        // Same timeout rule as recvRaw: a quiet moment mid-body is not the end
+        // of the body. Retrying here rather than returning 0 matters because
+        // doPut's Content-Length loop treats any <= 0 as end-of-stream and then
+        // reports the short body as an error.
         int readBody(char *buf, int len)
         {
-            int ret = httpd_req_recv(req, buf, len);
-            if (ret == HTTPD_SOCK_ERR_TIMEOUT)
-                /* Retry receiving if timeout occurred */
-                return 0;
+            for (int tries = 0; tries < RECV_TIMEOUT_RETRIES; ++tries)
+            {
+                int ret = httpd_req_recv(req, buf, len);
+                if (ret != HTTPD_SOCK_ERR_TIMEOUT)
+                    return ret;
+            }
 
-            return ret;
+            Debug_printv("recv timed out %d times, giving up len[%d]",
+                         RECV_TIMEOUT_RETRIES, len);
+            return -1;
         }
 
     private:
         httpd_req_t *req;
+
+        // Chunked-decoder state
+        bool chunkedKnown = false;
+        bool chunkedFlag = false;
+        size_t chunkLeft = 0;       // data bytes left in the current chunk
+        bool chunksDone = false;    // body complete
+        bool broken = false;        // socket/protocol error mid-body
+        bool continueSent = false;  // "100 Continue" already sent
+        bool unterminated = false;  // stopped on the expected length, framing unread
+        size_t bodyDone = 0;        // data bytes delivered so far
+        bool expectedKnown = false;
+        size_t expectedLen = 0;
+
+        // Raw-body source: the prefix captured by the session recv override
+        // (bytes the parser already read off the socket), then the socket for
+        // the remainder. captureFailed means the prefix was unavailable, so a
+        // chunked body cannot be read reliably.
+        bool capInit = false;
+        bool captureFailed = false;
+        const char *capBuf = nullptr;
+        size_t capPos = 0;
+        size_t capEnd = 0;
+        void initCapture();
+
+        int recvRaw(char *buf, size_t len);
+        bool recvByte(char *c);
+        bool readChunkLine(char *line, size_t cap);
+        int chunkFail()
+        {
+            broken = true;
+            return -1;
+        }
 
     protected:
         std::string path;

--- a/lib/www/webdav/webdav_server.cpp
+++ b/lib/www/webdav/webdav_server.cpp
@@ -203,11 +203,25 @@ static int mfile_copy_recursive(const std::string &source, const std::string &de
 
 static void discardRequestBody(Request &req)
 {
+    char buffer[512];
+
+    if (req.isChunked())
+    {
+        // Finder PUTs junk files (._*, .DS_Store) chunked too; drain them so
+        // the socket isn't left mid-body. readBodyChunked stops on the
+        // expected length (leaving the connection non-reusable, so it is then
+        // closed), or returns 0/negative at end/on error.
+        req.handleExpect();
+        while (req.readBodyChunked(buffer, sizeof(buffer)) > 0)
+            ;
+        return;
+    }
+
     int remaining = req.getContentLength();
     if (remaining <= 0)
         return;
 
-    char buffer[512];
+    req.handleExpect();
     while (remaining > 0)
     {
         int r = req.readBody(buffer, std::min(remaining, static_cast<int>(sizeof(buffer))));
@@ -993,9 +1007,9 @@ int Server::doPut(Request &req, Response &resp)
     if (!stream || !stream->isOpen())
         return 404;
 
-    int remaining = req.getContentLength();
-
     // 16 KB: fewer read/write iterations per PUT; buffer lives in PSRAM.
+    // (The Content-Length case declares its own `remaining` below; the chunked
+    // case has no Content-Length to work from.)
     const int chunkSize = 16384;
     uint8_t *chunk = (uint8_t *)malloc(chunkSize);
     if (!chunk) {
@@ -1005,19 +1019,47 @@ int Server::doPut(Request &req, Response &resp)
 
     int ret = 0;
 
-    while (remaining > 0)
-    {
-        int r = req.readBody((char *)chunk, std::min(remaining, chunkSize));
-        if (r <= 0)
-            break;
+    req.handleExpect();
 
-        if ((int)stream->write(chunk, r) != r)
+    if (req.isChunked())
+    {
+        // Transfer-Encoding: chunked (macOS Finder) -- no Content-Length; the
+        // decoder returns 0 at end-of-body, <0 on error. On error the
+        // connection is desynchronized; webdav_handler closes it.
+        for (;;)
         {
-            ret = -1;
-            break;
+            int r = req.readBodyChunked((char *)chunk, chunkSize);
+            if (r == 0)
+                break;
+            if (r < 0 || (int)stream->write(chunk, r) != r)
+            {
+                ret = -1;
+                break;
+            }
+        }
+    }
+    else
+    {
+        int remaining = req.getContentLength();
+
+        while (remaining > 0)
+        {
+            int r = req.readBody((char *)chunk, std::min(remaining, chunkSize));
+            if (r <= 0)
+                break;
+
+            if ((int)stream->write(chunk, r) != r)
+            {
+                ret = -1;
+                break;
+            }
+
+            remaining -= r;
         }
 
-        remaining -= r;
+        if (remaining > 0 && ret == 0)
+            ret = -1;   // truncated body (recv timeout): report it, don't
+                        // return 201 for a short file
     }
 
     free(chunk);


### PR DESCRIPTION
Alternative to #51. **Same fixes, same behaviour, but without vendoring a patched copy of `esp_http_server`.** Open both so you can pick the approach you prefer — please merge only one.

Fixes #53
Fixes #52

## Same two bugs as #51

- **`.local` lookups stall 5s** — `mdns_init()` ran with no IPv6 address, so the responder never answered the AAAA query macOS pairs with every A query. One `esp_netif_create_ip6_linklocal()` before mDNS starts. (Identical commit to #51.)
- **Finder copies arrive as 0 bytes** — Finder PUTs `Transfer-Encoding: chunked` with no `Content-Length`; stock `doPut` reads only Content-Length bodies, so it wrote nothing and answered 201. Plus the recv-timeout-is-not-fatal fix and the `X-Expected-Entity-Length` deadlock break (Finder withholds the chunk terminator until it sees a response).

## The difference: how we read the chunked body

`esp_http_server` can't hand a chunked body to a handler — `http_parser` de-chunks it and eats the first chunk-size line before the handler runs (documented: *"Presently Chunked Encoding is not supported"*).

- **#51** vendors the whole component and patches its parser to pause at end-of-headers.
- **This PR** uses the public `httpd_sess_set_recv_override()` to install a per-connection "tee" at connection open (`body_capture.*`): it copies the bytes the parser reads off the socket into a small, bounded, per-request buffer. `doPut` then de-chunks straight from that buffer, falling through to the socket (`httpd_default_recv`) for the remainder. The two sources never overlap. No component fork.

The capture buffer is bounded (4 KB) and reset per request; on overflow it stops copying, so large POST / websocket traffic never makes it grow.

## Trade-off

|  | #51 (fork) | this PR (tee) |
|---|---|---|
| diff size | ~7,100 lines (mostly the copied IDF component) | ~580 lines |
| tracks an IDF component copy | yes | no |
| per-connection cost | none | one bounded capture buffer |

## Verified on ESP32-S3 hardware

347 B / 3 KB / 5 KB / 20 KB chunked PUTs with the terminator withheld all return 201 in ~0.2s and read back **byte-exact (md5)** — including a chunked PUT following a PROPFIND on the same keep-alive connection (exercises the per-request buffer reset). Content-Length PUTs and the junk-path (`._*`, `.DS_Store`) drain still work.

A/B against #51 on identical hardware shows no latency difference (keep-alive PROPFIND ~90 ms on both; the recv-override adds nothing measurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)